### PR TITLE
add global & local options to help output

### DIFF
--- a/internal/command/plan_output.go
+++ b/internal/command/plan_output.go
@@ -14,14 +14,12 @@ import (
 type OutputPlanCommand struct {
 	*Meta
 
-	PlanID   string
-	Location string
+	PlanID string
 }
 
 func (c *OutputPlanCommand) flags() *flag.FlagSet {
 	f := c.flagSet("plan output")
 	f.StringVar(&c.PlanID, "plan", "", "The plan ID to retrieve JSON execution plan.")
-	f.StringVar(&c.Location, "location", "", "Location of where to persist the plan execution file.")
 
 	return f
 }
@@ -66,7 +64,21 @@ func (c *OutputPlanCommand) addPlanDetails(plan *tfe.Plan) {
 
 func (c *OutputPlanCommand) Help() string {
 	helpText := `
-Usage: tfci plan output [options]
+Usage: tfci [global options] plan output [options]
+
+	Returns the plan details for the provided Plan ID.
+
+Global Options:
+
+	-hostname       The hostname of a Terraform Enterprise installation, if using Terraform Enterprise. Defaults to "app.terraform.io".
+
+	-token          The token used to authenticate with Terraform Cloud. Defaults to reading "TF_API_TOKEN" environment variable.
+
+	-organization   Terraform Cloud Organization Name.
+
+Options:
+
+	-plan           Returns the plan details for the provided Plan ID.
 	`
 	return strings.TrimSpace(helpText)
 }

--- a/internal/command/run_apply.go
+++ b/internal/command/run_apply.go
@@ -21,7 +21,7 @@ type ApplyRunCommand struct {
 
 func (c *ApplyRunCommand) flags() *flag.FlagSet {
 	f := c.flagSet("run apply")
-	f.StringVar(&c.RunID, "run", "", "Existing Terraform Cloud Run ID to Apply")
+	f.StringVar(&c.RunID, "run", "", "Existing Terraform Cloud Run ID to Apply.")
 	f.StringVar(&c.Comment, "comment", "", "An optional comment about the run.")
 
 	return f
@@ -118,7 +118,23 @@ func (c *ApplyRunCommand) readApplyLogs(run *tfe.Run) {
 
 func (c *ApplyRunCommand) Help() string {
 	helpText := `
-Usage: tfci run apply [options]
+Usage: tfci [global options] run apply [options]
+
+	Applies a run that is paused waiting for confirmation after a plan.
+
+Global Options:
+
+	-hostname       The hostname of a Terraform Enterprise installation, if using Terraform Enterprise. Defaults to "app.terraform.io".
+
+	-token          The token used to authenticate with Terraform Cloud. Defaults to reading "TF_API_TOKEN" environment variable.
+
+	-organization   Terraform Cloud Organization Name.
+
+Options:
+
+	-run         Existing Terraform Cloud Run ID to Apply.
+
+	-comment     An optional comment about the run.
 	`
 	return strings.TrimSpace(helpText)
 }

--- a/internal/command/run_cancel.go
+++ b/internal/command/run_cancel.go
@@ -22,7 +22,7 @@ type CancelRunCommand struct {
 
 func (c *CancelRunCommand) flags() *flag.FlagSet {
 	f := c.flagSet("run cancel")
-	f.StringVar(&c.RunID, "run", "", "Existing Terraform Cloud Run ID to Discard")
+	f.StringVar(&c.RunID, "run", "", "Existing Terraform Cloud Run ID to Discard.")
 	f.StringVar(&c.Comment, "comment", "", "An optional comment about the run.")
 	f.BoolVar(&c.ForceCancel, "force-cancel", false, "Ends the run immediately.")
 
@@ -111,7 +111,25 @@ func (c *CancelRunCommand) addRunDetails(run *tfe.Run) {
 
 func (c *CancelRunCommand) Help() string {
 	helpText := `
-Usage: tfci run cancel [options]
+Usage: tfci [global options] run cancel [options]
+
+	Interrupts a run that is currently planning or applying.
+
+Global Options:
+
+	-hostname       The hostname of a Terraform Enterprise installation, if using Terraform Enterprise. Defaults to "app.terraform.io".
+
+	-token          The token used to authenticate with Terraform Cloud. Defaults to reading "TF_API_TOKEN" environment variable.
+
+	-organization   Terraform Cloud Organization Name.
+
+Options:
+
+  -run            Existing Terraform Cloud Run ID to Discard.
+
+	-comment        An optional comment about the run.
+
+	-force-cancel   Ends the run immediately.
 	`
 	return strings.TrimSpace(helpText)
 }

--- a/internal/command/run_create.go
+++ b/internal/command/run_create.go
@@ -25,10 +25,10 @@ type CreateRunCommand struct {
 
 func (c *CreateRunCommand) flags() *flag.FlagSet {
 	f := c.flagSet("run create")
-	f.StringVar(&c.Workspace, "workspace", "", "The Configuration Version ID that was created.")
-	f.StringVar(&c.ConfigurationVersionID, "configuration_version", "", "Specifies the configuration version to use for this run.")
-	f.StringVar(&c.Message, "message", "", "Specifies the message to be associated with this run.")
-	f.BoolVar(&c.PlanOnly, "plan-only", false, "Specifies if this is a speculative, plan-only run that Terraform cannot apply. Often used in conjunction with terraform-version in order to test whether an upgrade would succeed.")
+	f.StringVar(&c.Workspace, "workspace", "", "The name of the Terraform Cloud Workspace.")
+	f.StringVar(&c.ConfigurationVersionID, "configuration_version", "", "The Configuration Version ID to use for this run.")
+	f.StringVar(&c.Message, "message", "", "Specifies the message to be associated with this run. A default message will be set.")
+	f.BoolVar(&c.PlanOnly, "plan-only", false, "Specifies if this is a Terraform Cloud speculative, plan-only run that cannot be applied.")
 
 	return f
 }
@@ -131,7 +131,27 @@ func (c *CreateRunCommand) defaultRunMessage() string {
 
 func (c *CreateRunCommand) Help() string {
 	helpText := `
-Usage: tfci run create [options]
+Usage: tfci [global options] run create [options]
+
+	Performs a new plan run in Terraform Cloud, using a configuration version and the workspace's current variables
+
+Global Options:
+
+	-hostname       The hostname of a Terraform Enterprise installation, if using Terraform Enterprise. Defaults to "app.terraform.io".
+
+	-token          The token used to authenticate with Terraform Cloud. Defaults to reading "TF_API_TOKEN" environment variable.
+
+	-organization   Terraform Cloud Organization Name.
+
+Options:
+
+	-workspace              The name of the Terraform Cloud Workspace.
+
+	-configuration_version  The Configuration Version ID to use for this run.
+
+	-message                Specifies the message to be associated with this run. A default message will be set.
+
+	-plan-only              Specifies if this is a Terraform Cloud speculative, plan-only run that cannot be applied.
 	`
 	return strings.TrimSpace(helpText)
 }

--- a/internal/command/run_discard.go
+++ b/internal/command/run_discard.go
@@ -101,7 +101,23 @@ func (c *DiscardRunCommand) addRunDetails(run *tfe.Run) {
 
 func (c *DiscardRunCommand) Help() string {
 	helpText := `
-Usage: tfci run discard [options]
+Usage: tfci [global options] run discard [options]
+
+	Skips any remaining work on runs that are paused waiting for confirmation or priority.
+
+Global Options:
+
+	-hostname       The hostname of a Terraform Enterprise installation, if using Terraform Enterprise. Defaults to "app.terraform.io".
+
+	-token          The token used to authenticate with Terraform Cloud. Defaults to reading "TF_API_TOKEN" environment variable.
+
+	-organization   Terraform Cloud Organization Name.
+
+Options:
+
+	-run         Existing Terraform Cloud Run ID to Discard.
+
+	-comment     An optional comment about the run.
 	`
 	return strings.TrimSpace(helpText)
 }

--- a/internal/command/run_show.go
+++ b/internal/command/run_show.go
@@ -91,7 +91,21 @@ func (c *ShowRunCommand) addRunDetails(run *tfe.Run) {
 
 func (c *ShowRunCommand) Help() string {
 	helpText := `
-Usage: tfci run show [options]
+Usage: tfci [global options] run show [options]
+
+	Returns run details for the provided Terraform Cloud run ID.
+
+Global Options:
+
+	-hostname       The hostname of a Terraform Enterprise installation, if using Terraform Enterprise. Defaults to "app.terraform.io".
+
+	-token          The token used to authenticate with Terraform Cloud. Defaults to reading "TF_API_TOKEN" environment variable.
+
+	-organization   Terraform Cloud Organization Name.
+
+Options:
+
+	-run            Existing Terraform Cloud Run ID to show.
 	`
 	return strings.TrimSpace(helpText)
 }

--- a/internal/command/upload.go
+++ b/internal/command/upload.go
@@ -85,7 +85,25 @@ func (c *UploadConfigurationCommand) addConfigurationDetails(config *tfe.Configu
 
 func (c *UploadConfigurationCommand) Help() string {
 	helpText := `
-Usage: tfci upload [options]
+Usage: tfci [global options] upload [options]
+
+	Creates and uploads a new configuration version for the provided workspace
+
+Global Options:
+
+	-hostname       The hostname of a Terraform Enterprise installation, if using Terraform Enterprise. Defaults to "app.terraform.io".
+
+	-token          The token used to authenticate with Terraform Cloud. Defaults to reading "TF_API_TOKEN" environment variable.
+
+	-organization   Terraform Cloud Organization Name.
+
+Options:
+
+	-workspace      The name of the Terraform Cloud Workspace to create and upload the terraform configuration version in.
+
+	-directory      Path to the terraform configuration files on disk.
+
+	-speculative    When true, this configuration version may only be used to create runs which are speculative, that is, can neither be confirmed nor applied.
 	`
 	return strings.TrimSpace(helpText)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Adds both global and local command options to the `--help` flag command.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
