### PR TITLE
Updated codeowners to reflect new team name

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hashicorp/tf-vcs
+* @hashicorp/tf-nexus


### PR DESCRIPTION
## Description

TF-VCS is now TF-Nexus. This change updates codeowners to reflect that.
