### PR TITLE
Update USAGE.md

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -25,7 +25,7 @@ docker pull hashicorp/tfci:v1.0.0
 
 Then run the container.
 
-You are able to pass exported environment variables `TF_HOSTNAME`, `TF_API_TOKEN`, `TF_CLOUD_ORGANIZATION` from the parent process.
+You are able to pass exported environment variables `TF_HOSTNAME` (if using Terraform Enterprise), `TF_API_TOKEN`, `TF_CLOUD_ORGANIZATION` from the parent process.
 
 ```sh
 docker run -it --rm \
@@ -66,7 +66,7 @@ These environment variables are passed to custom Docker GitHub Actions
 
 *.envrc*
 ```sh
-export TF_HOSTNAME="<redacted>"
+export TF_HOSTNAME="my-enterprise-tf-instance.example.com"
 export TF_CLOUD_ORGANIZATION="<redacted>"
 export TF_API_TOKEN="<redacted>"
 # GitHub ENV


### PR DESCRIPTION
clarify purpose of TF_HOSTNAME

<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

The purpose of `TF_HOSTNAME` is unclear to the reader who is a prospective `tfci` user and is encountering the tooling repo before having run the CLI for the first time. While composing my first command, it was unclear what is an appropriate value for `TF_HOSTNAME`. It was necessary for me to investigate the CLI's built-in usage hints to realize that I did not need to provide this variable because I am not using TF Enterprise.

