### PR TITLE
Make `Command.Synopsis()` implementations one line

### DIFF
--- a/internal/command/plan_output.go
+++ b/internal/command/plan_output.go
@@ -84,5 +84,5 @@ Options:
 }
 
 func (c *OutputPlanCommand) Synopsis() string {
-	return c.Help()
+	return "Returns the plan details for the provided Plan ID"
 }

--- a/internal/command/run_apply.go
+++ b/internal/command/run_apply.go
@@ -140,5 +140,5 @@ Options:
 }
 
 func (c *ApplyRunCommand) Synopsis() string {
-	return c.Help()
+	return "Applies a run that is paused waiting for confirmation after a plan"
 }

--- a/internal/command/run_cancel.go
+++ b/internal/command/run_cancel.go
@@ -135,5 +135,5 @@ Options:
 }
 
 func (c *CancelRunCommand) Synopsis() string {
-	return c.Help()
+	return "Interrupts a run that is currently planning or applying"
 }

--- a/internal/command/run_create.go
+++ b/internal/command/run_create.go
@@ -133,7 +133,7 @@ func (c *CreateRunCommand) Help() string {
 	helpText := `
 Usage: tfci [global options] run create [options]
 
-	Performs a new plan run in Terraform Cloud, using a configuration version and the workspace's current variables
+	Performs a new plan run in Terraform Cloud, using a configuration version and the workspace's current variables.
 
 Global Options:
 
@@ -157,5 +157,5 @@ Options:
 }
 
 func (c *CreateRunCommand) Synopsis() string {
-	return c.Help()
+	return "Performs a new plan run in Terraform Cloud, using a configuration version and the workspace's current variables"
 }

--- a/internal/command/run_discard.go
+++ b/internal/command/run_discard.go
@@ -123,5 +123,5 @@ Options:
 }
 
 func (c *DiscardRunCommand) Synopsis() string {
-	return c.Help()
+	return "Skips any remaining work on runs that are paused waiting for confirmation or priority"
 }

--- a/internal/command/run_show.go
+++ b/internal/command/run_show.go
@@ -111,5 +111,5 @@ Options:
 }
 
 func (c *ShowRunCommand) Synopsis() string {
-	return c.Help()
+	return "Returns run details for the provided Terraform Cloud run ID"
 }

--- a/internal/command/upload.go
+++ b/internal/command/upload.go
@@ -87,7 +87,7 @@ func (c *UploadConfigurationCommand) Help() string {
 	helpText := `
 Usage: tfci [global options] upload [options]
 
-	Creates and uploads a new configuration version for the provided workspace
+	Creates and uploads a new configuration version for the provided workspace.
 
 Global Options:
 
@@ -109,5 +109,5 @@ Options:
 }
 
 func (c *UploadConfigurationCommand) Synopsis() string {
-	return c.Help()
+	return "Creates and uploads a new configuration version for the provided workspace"
 }


### PR DESCRIPTION
## Description

From mitchellh/cli `Command.Synopsis()` is supposed to output a [single line](https://github.com/mitchellh/cli/blob/v1.1.5/command.go#L28-L30), as the `Command.Help()` is used when requesting detailed help about a specific command. This corrects all the existing `Synopsis()` implementations.

This fixes #13.

This change also addresses some formatting inconsistencies: commands are standardized on ending their `Help()` synopsis output with a period, but some were missing.

## Testing plan

1. `TF_API_TOKEN=abc go run . -- run`
2. See the following output:
```
This command is accessed by using one of the subcommands below.

Subcommands:
    apply      Applies a run that is paused waiting for confirmation after a plan
    cancel     Interrupts a run that is currently planning or applying
    create     Performs a new plan run in Terraform Cloud, using a configuration version and the workspace's current variables
    discard    Skips any remaining work on runs that are paused waiting for confirmation or priority
    show       Returns run details for the provided Terraform Cloud run ID
exit status 1
```