### PR TITLE
Fix create run command to account for auto apply workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# UNRELEASED
+
+## Enhancements
+* Adds [mitchellh/cli](https://github.com/mitchellh/cli) `Command.Synopsis()` by @ggambetti [#14](https://github.com/hashicorp/tfc-workflows-tooling/pull/14)
+
+## Bug Fixes
+* Fixes `run create` command for Auto Apply workspaces by @mjyocca [#16](https://github.com/hashicorp/tfc-workflows-tooling/pull/16)
+
 # v1.0.0
 
 First Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # UNRELEASED
 
 ## Enhancements
-* Adds [mitchellh/cli](https://github.com/mitchellh/cli) `Command.Synopsis()` by @ggambetti [#14](https://github.com/hashicorp/tfc-workflows-tooling/pull/14)
+* Adds [mitchellh/cli](https://github.com/mitchellh/cli) `Command.Synopsis()` to all commands by @ggambetti [#14](https://github.com/hashicorp/tfc-workflows-tooling/pull/14)
 
 ## Bug Fixes
 * Fixes `run create` command for Auto Apply workspaces by @mjyocca [#16](https://github.com/hashicorp/tfc-workflows-tooling/pull/16)

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -151,9 +151,8 @@ func (service *runService) CreateRun(ctx context.Context, options CreateRunOptio
 
 		log.Printf("[DEBUG] PlanOnly: %t, CostEstimation: %t, PolicyChecks: %t", r.PlanOnly, costEstimateEnabled, policyChecksEnabled)
 
-		desiredStatus := []tfe.RunStatus{tfe.RunPlannedAndFinished}
+		desiredStatus := []tfe.RunStatus{tfe.RunPlannedAndFinished, tfe.RunApplied}
 		if !r.PlanOnly {
-			desiredStatus = []tfe.RunStatus{tfe.RunPlannedAndFinished}
 			if costEstimateEnabled && !policyChecksEnabled {
 				desiredStatus = append(desiredStatus, tfe.RunCostEstimated)
 			} else if policyChecksEnabled {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Fixes issue for workspaces with auto apply enabled, executing the `run create` command and failing to quit gracefully.

Also including some changelog entries. We should start requesting for any code changes going forward.

Addresses Issue: #15 

## Testing plan

1.  Setup a Terraform Cloud workspace with auto apply enabled
1.  Issue the `run create` command with appropriate flags
1.  Confirm command successfully shuts down and does not continue to run.

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
