### PR TITLE
Prepare for v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Bug Fixes
 
+# v1.0.2
+
+## Bug Fixes
+
+* Upgrades [go-tfe](https://github.com/hashicorp/go-tfe) to `v1.28.0` to [avoid sending credentials during ConfigurationVersion upload](https://github.com/hashicorp/go-tfe/pull/717), as they are not necessary.
+
 # v1.0.1
 
 ## Enhancements


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Releases dependency updates to `go-tfe`.

## External links

There are also pending PRs on the dependant repositories for the `v1.0.2` release:
 * https://github.com/hashicorp/tfc-workflows-github/pull/11
 * https://github.com/hashicorp/tfc-workflows-gitlab/pull/8

Specifically to pick up https://github.com/hashicorp/go-tfe/pull/717.

