### PR TITLE
Refactor for output interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ log/
 tmp
 .envrc
 
+.env
+
+.vscode/*
+
 ## Terraform
 # Local .terraform directories
 **/.terraform/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Enhancements
 * Upgrades [go-tfe](https://github.com/hashicorp/go-tfe) to `v1.29.0`.
+* Internal refactor for output interface by @mjyocca [#22](https://github.com/hashicorp/tfc-workflows-tooling/pull/22)
 
 ## Bug Fixes
 * Fixes issue with runs incorrectly marked as `Error` when status ends in `policy_soft_failed` by @mjyocca [#23](https://github.com/hashicorp/tfc-workflows-tooling/pull/23)

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -83,7 +83,11 @@ func (c *Meta) closeOutput() string {
 		}
 		// some outputs we may want to exclude for platform
 		if m.IncludeWithPlatform() {
-			platOutput[m.name] = m
+			val, err := m.Value()
+			// if it has errored, don't include value
+			if err != nil {
+				platOutput[m.name] = environment.NewOutput(val, m.multiLine)
+			}
 		}
 	}
 

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -80,15 +80,17 @@ func (c *Meta) closeOutput() string {
 	for _, m := range c.messages {
 		// some values we may want to exclude for stdout
 		if m.stdOut {
+			// add raw interface{} value to stdout
 			stdOutput[m.name] = m.value
 		}
 		// some outputs we may want to exclude for platform
 		if m.IncludeWithPlatform() {
+			// convert to string
 			val, err := m.Value()
 			// if error, add to logger
 			if err != nil {
 				log.Printf("[ERROR] problem writing output: '%s', with: %s", m.name, err.Error())
-				// don't include value to platform is issue serializing
+				// don't include value if issue serializing value
 				continue
 			}
 			platOutput[m.name] = environment.NewOutput(val, m.multiLine)

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -85,13 +85,13 @@ func (c *Meta) closeOutput() string {
 		// some outputs we may want to exclude for platform
 		if m.IncludeWithPlatform() {
 			val, err := m.Value()
-			// if it has errored, don't include value
+			// if error, add to logger
 			if err != nil {
-				platOutput[m.name] = environment.NewOutput(val, m.multiLine)
-			} else {
-				// add error to logger
 				log.Printf("[ERROR] problem writing output: '%s', with: %s", m.name, err.Error())
+				// don't include value to platform is issue serializing
+				continue
 			}
+			platOutput[m.name] = environment.NewOutput(val, m.multiLine)
 		}
 	}
 

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -74,19 +74,6 @@ func (c *Meta) addOutputWithOpts(name string, value interface{}, opts *outputOpt
 	c.messageOutput[name] = msg
 }
 
-type PlatformOutput struct {
-	value     string
-	multiLine bool
-}
-
-func (p *PlatformOutput) Value() string {
-	return p.value
-}
-
-func (p *PlatformOutput) MultiLine() bool {
-	return p.multiLine
-}
-
 func (c *Meta) closeOutput() string {
 	stdOutput := make(map[string]interface{})
 	platOutput := environment.NewOutputMap()
@@ -96,10 +83,7 @@ func (c *Meta) closeOutput() string {
 			stdOutput[m.name] = m.value
 		}
 		if m.IncludeWithPlatform() {
-			platOutput[m.name] = &PlatformOutput{
-				value:     m.String(),
-				multiLine: m.multiLine,
-			}
+			platOutput[m.name] = m
 		}
 	}
 

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -35,7 +35,7 @@ type Meta struct {
 	// shared go-tfe client
 	cloud *cloud.Cloud
 	// messages for stdout, platform output
-	messages map[string]*OutputMessage
+	messages map[string]*outputMessage
 }
 
 func (c *Meta) flagSet(name string) *flag.FlagSet {
@@ -104,6 +104,6 @@ func (c *Meta) closeOutput() string {
 func NewMeta(c *cloud.Cloud) *Meta {
 	return &Meta{
 		cloud:    c,
-		messages: make(map[string]*OutputMessage),
+		messages: make(map[string]*outputMessage),
 	}
 }

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -35,7 +35,7 @@ type Meta struct {
 	// shared go-tfe client
 	cloud *cloud.Cloud
 	// messages for stdout, platform output
-	messageOutput map[string]*OutputMessage
+	messages map[string]*OutputMessage
 }
 
 func (c *Meta) flagSet(name string) *flag.FlagSet {
@@ -60,22 +60,12 @@ func (c *Meta) resolveStatus(err error) Status {
 
 // adds new output value to map as &OutputMessage{}
 func (c *Meta) addOutput(name string, value string) {
-	c.messageOutput[name] = newOutputMessage(name, value)
-}
-
-type outputOpts struct {
-	// indicates if value should be displayed to stdout
-	stdOut bool
-	// indicates if value contains a multiline value as some platforms: gitlab do not support multiline values in `.env`
-	multiLine bool
+	c.messages[name] = newOutputMessage(name, value, defaultOutputOpts)
 }
 
 // adds new output value with options &outputOpts{}
 func (c *Meta) addOutputWithOpts(name string, value interface{}, opts *outputOpts) {
-	msg := newOutputMessage(name, value)
-	msg.stdOut = opts.stdOut
-	msg.multiLine = opts.multiLine
-	c.messageOutput[name] = msg
+	c.messages[name] = newOutputMessage(name, value, opts)
 }
 
 // returns json result string, containing all outputs
@@ -86,7 +76,7 @@ func (c *Meta) closeOutput() string {
 	// map[string]OutputI interface
 	platOutput := environment.NewOutputMap()
 
-	for _, m := range c.messageOutput {
+	for _, m := range c.messages {
 		// some values we may want to exclude for stdout
 		if m.stdOut {
 			stdOutput[m.name] = m.value
@@ -113,7 +103,7 @@ func (c *Meta) closeOutput() string {
 
 func NewMeta(c *cloud.Cloud) *Meta {
 	return &Meta{
-		cloud:         c,
-		messageOutput: make(map[string]*OutputMessage),
+		cloud:    c,
+		messages: make(map[string]*OutputMessage),
 	}
 }

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"flag"
 	"io/ioutil"
+	"log"
 
 	"github.com/hashicorp/tfci/internal/cloud"
 	"github.com/hashicorp/tfci/internal/environment"
@@ -87,6 +88,9 @@ func (c *Meta) closeOutput() string {
 			// if it has errored, don't include value
 			if err != nil {
 				platOutput[m.name] = environment.NewOutput(val, m.multiLine)
+			} else {
+				// add error to logger
+				log.Printf("[ERROR] problem writing output: '%s', with: %s", m.name, err.Error())
 			}
 		}
 	}

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/jsonapi"
 )
 
-type OutputMessage struct {
+type outputMessage struct {
 	// unique name
 	name string
 	// raw value to return to stdout, platform
@@ -25,11 +25,11 @@ type OutputMessage struct {
 	multiLine bool
 }
 
-func (o *OutputMessage) IncludeWithPlatform() bool {
+func (o *outputMessage) IncludeWithPlatform() bool {
 	return o.platformOut
 }
 
-func (o *OutputMessage) String() (sValue string) {
+func (o *outputMessage) String() (sValue string) {
 	switch o.value.(type) {
 	case string:
 		sValue = fmt.Sprintf("%s", o.value)
@@ -57,7 +57,7 @@ func (o *OutputMessage) String() (sValue string) {
 	return
 }
 
-func (o *OutputMessage) MultiLine() bool {
+func (o *outputMessage) MultiLine() bool {
 	return o.multiLine
 }
 
@@ -76,8 +76,8 @@ type outputOpts struct {
 	multiLine bool
 }
 
-func newOutputMessage(name string, value interface{}, opts *outputOpts) *OutputMessage {
-	return &OutputMessage{
+func newOutputMessage(name string, value interface{}, opts *outputOpts) *outputMessage {
+	return &outputMessage{
 		name:        name,
 		value:       value,
 		stdOut:      opts.stdOut,

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -25,16 +25,6 @@ type OutputMessage struct {
 	multiLine bool
 }
 
-func newOutputMessage(name string, value interface{}) *OutputMessage {
-	return &OutputMessage{
-		name:        name,
-		value:       value,
-		stdOut:      true,
-		platformOut: true,
-		multiLine:   false,
-	}
-}
-
 func (o *OutputMessage) IncludeWithPlatform() bool {
 	return o.platformOut
 }
@@ -62,6 +52,20 @@ func (o *OutputMessage) String() (sValue string) {
 		}
 	}
 	return
+}
+
+func (o *OutputMessage) MultiLine() bool {
+	return o.multiLine
+}
+
+func newOutputMessage(name string, value interface{}) *OutputMessage {
+	return &OutputMessage{
+		name:        name,
+		value:       value,
+		stdOut:      true,
+		platformOut: true,
+		multiLine:   false,
+	}
 }
 
 type Marshaler string

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -78,7 +78,6 @@ func structHasJsonTags(t reflect.Type) (json bool, jsonAPI bool) {
 		apiTag := field.Tag.Get(apiLabel)
 		// as soon as we determine, return
 		if jsonTag != "" {
-			fmt.Println("found json tag")
 			json = true
 			return
 		}

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -6,6 +6,7 @@ package command
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"reflect"
 
 	"github.com/hashicorp/jsonapi"
@@ -52,9 +53,11 @@ func (o *outputMessage) Value() (string, error) {
 		// we detected jsonapi, use jsonapi.MarshalPayload. eg. *tfe.Run struct
 		case JSONAPI:
 			return marshalJsonAPI(o.value)
-		// everything else use standard json.Marshal
-		default:
+		// detected json tag annotations
+		case JSON:
 			return marshalJson(o.value)
+		default:
+			return "", fmt.Errorf("no marshaller found for %v", refType)
 		}
 	}
 }

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -61,13 +61,28 @@ func (o *OutputMessage) MultiLine() bool {
 	return o.multiLine
 }
 
-func newOutputMessage(name string, value interface{}) *OutputMessage {
+var defaultOutputOpts = &outputOpts{
+	stdOut:      true,
+	platformOut: true,
+	multiLine:   false,
+}
+
+type outputOpts struct {
+	// option that indicates if value should be displayed to stdout
+	stdOut bool
+	// option to include value to platform output when detected
+	platformOut bool
+	// option to indicate if value contains a multiline value as some platforms: gitlab do not support multiline values in `.env`
+	multiLine bool
+}
+
+func newOutputMessage(name string, value interface{}, opts *outputOpts) *OutputMessage {
 	return &OutputMessage{
 		name:        name,
 		value:       value,
-		stdOut:      true,
-		platformOut: true,
-		multiLine:   false,
+		stdOut:      opts.stdOut,
+		platformOut: opts.platformOut,
+		multiLine:   opts.multiLine,
 	}
 }
 

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -5,11 +5,100 @@ package command
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
 
 	"github.com/hashicorp/jsonapi"
 )
 
-func outputJson(data interface{}) (string, error) {
+type OutputMessage struct {
+	// unique name
+	name string
+	//
+	value interface{}
+	// determines if message should be included in stdout. default: true
+	stdOut bool
+	// determines if message should be sent to platform. default: true
+	platformOut bool
+	// if the value may contain strings/json that is multiline
+	multiLine bool
+}
+
+func newOutputMessage(name string, value interface{}) *OutputMessage {
+	return &OutputMessage{
+		name:        name,
+		value:       value,
+		stdOut:      true,
+		platformOut: true,
+		multiLine:   false,
+	}
+}
+
+func (o *OutputMessage) IncludeWithPlatform() bool {
+	return o.platformOut
+}
+
+func (o *OutputMessage) String() (sValue string) {
+	switch o.value.(type) {
+	case string:
+		sValue = fmt.Sprintf("%s", o.value)
+	default:
+		reflectVal := reflect.ValueOf(o.value)
+		reflectInd := reflect.Indirect(reflectVal)
+		refType := reflectInd.Type()
+		// if type is not a struct, return
+		if refType.Kind() != reflect.Struct {
+			b, _ := json.Marshal(o.value)
+			sValue = string(b)
+			return
+		}
+		// check struct tags for `json` or `jsonapi`
+		json, jsonAPI := structHasJsonTags(refType)
+		// if json, normal marshal
+		if json {
+			sValue, _ = marshalJson(o.value)
+			return
+		}
+		// use jsonapi marshal
+		if jsonAPI {
+			sValue, _ = marshalJsonAPI(o.value)
+			return
+		}
+	}
+	return
+}
+
+func structHasJsonTags(t reflect.Type) (json bool, jsonAPI bool) {
+	jsonLabel, apiLabel := "json", "jsonapi"
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		// Get the field tag value
+		jsonTag := field.Tag.Get(jsonLabel)
+		apiTag := field.Tag.Get(apiLabel)
+		// as soon as we determine, return
+		if jsonTag != "" {
+			fmt.Println("found json tag")
+			json = true
+			return
+		}
+		if apiTag != "" {
+			jsonAPI = true
+			return
+		}
+	}
+	return json, jsonAPI
+}
+
+func marshalJson(data interface{}) (string, error) {
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func marshalJsonAPI(data interface{}) (string, error) {
 	buffer := new(bytes.Buffer)
 
 	err := jsonapi.MarshalPayload(buffer, data)

--- a/internal/command/plan_output.go
+++ b/internal/command/plan_output.go
@@ -58,8 +58,10 @@ func (c *OutputPlanCommand) addPlanDetails(plan *tfe.Plan) {
 	c.addOutput("change", fmt.Sprint(plan.ResourceChanges))
 	c.addOutput("destroy", fmt.Sprint(plan.ResourceDestructions))
 
-	planJson, _ := outputJson(plan)
-	c.addOutput("payload", planJson)
+	c.addOutputWithOpts("payload", plan, &outputOpts{
+		stdOut:    false,
+		multiLine: true,
+	})
 }
 
 func (c *OutputPlanCommand) Help() string {

--- a/internal/command/run_create.go
+++ b/internal/command/run_create.go
@@ -101,8 +101,11 @@ func (c *CreateRunCommand) addRunDetails(run *tfe.Run) {
 			c.Ui.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
 		}
 	}
-	runJson, _ := outputJson(run)
-	c.addOutput("payload", runJson)
+
+	c.addOutputWithOpts("payload", run, &outputOpts{
+		stdOut:    false,
+		multiLine: true,
+	})
 }
 
 func (c *CreateRunCommand) readPlanLogs(run *tfe.Run) {

--- a/internal/command/run_show.go
+++ b/internal/command/run_show.go
@@ -85,8 +85,10 @@ func (c *ShowRunCommand) addRunDetails(run *tfe.Run) {
 		}
 	}
 
-	payloadJson, _ := outputJson(run)
-	c.addOutput("payload", payloadJson)
+	c.addOutputWithOpts("payload", run, &outputOpts{
+		stdOut:    false,
+		multiLine: true,
+	})
 }
 
 func (c *ShowRunCommand) Help() string {

--- a/internal/command/upload.go
+++ b/internal/command/upload.go
@@ -79,8 +79,11 @@ func (c *UploadConfigurationCommand) addConfigurationDetails(config *tfe.Configu
 		c.addOutput("configuration_version_id", config.ID)
 		c.addOutput("configuration_version_status", string(config.Status))
 	}
-	configPayload, _ := outputJson(config)
-	c.addOutput("payload", configPayload)
+
+	c.addOutputWithOpts("payload", config, &outputOpts{
+		stdOut:    false,
+		multiLine: true,
+	})
 }
 
 func (c *UploadConfigurationCommand) Help() string {

--- a/internal/environment/env.go
+++ b/internal/environment/env.go
@@ -47,6 +47,26 @@ func NewOutputMap() OutputMap {
 	return OutputMap{}
 }
 
+type Output struct {
+	value     string
+	multiLine bool
+}
+
+func (o *Output) String() string {
+	return o.value
+}
+
+func (o *Output) MultiLine() bool {
+	return o.multiLine
+}
+
+func NewOutput(val string, multiLine bool) *Output {
+	return &Output{
+		value:     val,
+		multiLine: multiLine,
+	}
+}
+
 type Common interface {
 	ID() string
 	SHA() string

--- a/internal/environment/env.go
+++ b/internal/environment/env.go
@@ -32,14 +32,24 @@ type CI struct {
 	getenv GetEnv
 }
 
+type OutputI interface {
+	MultiLine() bool
+	Value() string
+}
+
+type OutputMap map[string]OutputI
+
+func NewOutputMap() OutputMap {
+	return OutputMap{}
+}
+
 type Common interface {
 	ID() string
 	SHA() string
 	SHAShort() string
 	Author() string
 	WriteDir() string // where to store tmp files
-	AddOutput(k, v string)
-	GetMessages() map[string]string
+	SetOutput(output OutputMap)
 	CloseOutput() error
 }
 

--- a/internal/environment/env.go
+++ b/internal/environment/env.go
@@ -42,11 +42,12 @@ type OutputWriter interface {
 
 type OutputMap map[string]OutputWriter
 
-// return type map to padd to SetOutput(OutputMap)
+// return type map to pass to SetOutput(OutputMap)
 func NewOutputMap() OutputMap {
 	return OutputMap{}
 }
 
+// exported struct that satisfies OutputWriter interface
 type Output struct {
 	value     string
 	multiLine bool

--- a/internal/environment/env.go
+++ b/internal/environment/env.go
@@ -33,14 +33,14 @@ type CI struct {
 }
 
 // interface to allow dependency injection that satisfies contract
-type OutputI interface {
+type OutputWriter interface {
 	// determines complex value and each platform can determine how to handle
 	MultiLine() bool
 	// resolves string value for the interface{}
 	String() string
 }
 
-type OutputMap map[string]OutputI
+type OutputMap map[string]OutputWriter
 
 // return type map to padd to SetOutput(OutputMap)
 func NewOutputMap() OutputMap {

--- a/internal/environment/env.go
+++ b/internal/environment/env.go
@@ -34,7 +34,7 @@ type CI struct {
 
 type OutputI interface {
 	MultiLine() bool
-	Value() string
+	String() string
 }
 
 type OutputMap map[string]OutputI

--- a/internal/environment/env.go
+++ b/internal/environment/env.go
@@ -32,13 +32,17 @@ type CI struct {
 	getenv GetEnv
 }
 
+// interface to allow dependency injection that satisfies contract
 type OutputI interface {
+	// determines complex value and each platform can determine how to handle
 	MultiLine() bool
+	// resolves string value for the interface{}
 	String() string
 }
 
 type OutputMap map[string]OutputI
 
+// return type map to padd to SetOutput(OutputMap)
 func NewOutputMap() OutputMap {
 	return OutputMap{}
 }

--- a/internal/environment/github.go
+++ b/internal/environment/github.go
@@ -32,7 +32,7 @@ type GitHubContext struct {
 	// path to ::set-output
 	githubOutput string
 	// data sent to GITHUB_OUTPUT
-	output map[string]string
+	output OutputMap
 	//
 	fileDelimeter string
 }
@@ -59,12 +59,8 @@ func (gh *GitHubContext) WriteDir() string {
 	return gh.runnerTemp
 }
 
-func (gh *GitHubContext) AddOutput(k, v string) {
-	gh.output[k] = v
-}
-
-func (gh *GitHubContext) GetMessages() map[string]string {
-	return gh.output
+func (gh *GitHubContext) SetOutput(output OutputMap) {
+	gh.output = output
 }
 
 func (gh *GitHubContext) CloseOutput() (retErr error) {
@@ -77,7 +73,7 @@ func (gh *GitHubContext) CloseOutput() (retErr error) {
 
 	data := []string{}
 	for k, v := range gh.output {
-		data = append(data, multiLineStrVal(gh.fileDelimeter, k, v))
+		data = append(data, multiLineStrVal(gh.fileDelimeter, k, v.Value()))
 	}
 	out := []byte(strings.Join(data, EOF))
 
@@ -93,7 +89,7 @@ func (gh *GitHubContext) CloseOutput() (retErr error) {
 	}
 
 	// reset output
-	gh.output = make(map[string]string)
+	gh.output = make(map[string]OutputI)
 
 	return
 }
@@ -109,7 +105,7 @@ func newGitHubContext(getenv GetEnv) *GitHubContext {
 		refType:      getenv("GITHUB_REF_TYPE"),
 		githubOutput: getenv("GITHUB_OUTPUT"),
 		runnerTemp:   getenv("RUNNER_TEMP"),
-		output:       make(map[string]string),
+		output:       make(map[string]OutputI),
 	}
 	// set random/unique to each github action runner
 	ghCtx.fileDelimeter = fmt.Sprintf("_GH%s%sFD_", ghCtx.runId, ghCtx.runNumber)

--- a/internal/environment/github.go
+++ b/internal/environment/github.go
@@ -73,7 +73,7 @@ func (gh *GitHubContext) CloseOutput() (retErr error) {
 
 	data := []string{}
 	for k, v := range gh.output {
-		data = append(data, multiLineStrVal(gh.fileDelimeter, k, v.Value()))
+		data = append(data, multiLineStrVal(gh.fileDelimeter, k, v.String()))
 	}
 	out := []byte(strings.Join(data, EOF))
 

--- a/internal/environment/github.go
+++ b/internal/environment/github.go
@@ -89,7 +89,7 @@ func (gh *GitHubContext) CloseOutput() (retErr error) {
 	}
 
 	// reset output
-	gh.output = make(map[string]OutputI)
+	gh.output = make(map[string]OutputWriter)
 
 	return
 }
@@ -105,7 +105,7 @@ func newGitHubContext(getenv GetEnv) *GitHubContext {
 		refType:      getenv("GITHUB_REF_TYPE"),
 		githubOutput: getenv("GITHUB_OUTPUT"),
 		runnerTemp:   getenv("RUNNER_TEMP"),
-		output:       make(map[string]OutputI),
+		output:       make(map[string]OutputWriter),
 	}
 	// set random/unique to each github action runner
 	ghCtx.fileDelimeter = fmt.Sprintf("_GH%s%sFD_", ghCtx.runId, ghCtx.runNumber)

--- a/internal/environment/github_test.go
+++ b/internal/environment/github_test.go
@@ -52,6 +52,19 @@ func createOutFile(t *testing.T, path string) {
 	})
 }
 
+type testOutput struct {
+	val       string
+	multiLine bool
+}
+
+func (o *testOutput) MultiLine() bool {
+	return o.multiLine
+}
+
+func (o *testOutput) Value() string {
+	return o.val
+}
+
 func Test_GitHubOutput(t *testing.T) {
 	env := getEnvMock(t)
 	path, _ := filepath.Abs(env["GITHUB_OUTPUT"])
@@ -63,8 +76,10 @@ func Test_GitHubOutput(t *testing.T) {
 	}
 	github := newGitHubContext(getenv)
 
-	github.AddOutput("k", "v")
-	github.AddOutput("v", "m")
+	github.SetOutput(OutputMap{
+		"k": &testOutput{val: "v"},
+		"v": &testOutput{val: "k"},
+	})
 
 	err := github.CloseOutput()
 	if err != nil {

--- a/internal/environment/github_test.go
+++ b/internal/environment/github_test.go
@@ -61,7 +61,7 @@ func (o *testOutput) MultiLine() bool {
 	return o.multiLine
 }
 
-func (o *testOutput) Value() string {
+func (o *testOutput) String() string {
 	return o.val
 }
 

--- a/internal/environment/gitlab.go
+++ b/internal/environment/gitlab.go
@@ -87,13 +87,13 @@ func (gl *GitLabContext) CloseOutput() (err error) {
 	var lines []string
 	for k, v := range gl.output {
 		if v.MultiLine() {
-			if err = writeArtifact(gl.jobName, k, v.Value()); err != nil {
+			if err = writeArtifact(gl.jobName, k, v.String()); err != nil {
 				return
 			}
 			continue
 		}
 
-		line := fmt.Sprintf("%s=%s", k, v.Value())
+		line := fmt.Sprintf("%s=%s", k, v.String())
 		lines = append(lines, line)
 	}
 

--- a/internal/environment/gitlab.go
+++ b/internal/environment/gitlab.go
@@ -119,6 +119,6 @@ func newGitLabContext(getenv GetEnv) *GitLabContext {
 		commitAuthor:        getenv("CI_COMMIT_AUTHOR"),
 		commitMessage:       getenv("CI_COMMIT_MESSAGE"),
 		commitRefName:       getenv("CI_COMMIT_REF_NAME"),
-		output:              make(map[string]OutputI),
+		output:              make(map[string]OutputWriter),
 	}
 }

--- a/internal/environment/gitlab_test.go
+++ b/internal/environment/gitlab_test.go
@@ -78,7 +78,7 @@ func TestCloseOutput(t *testing.T) {
 			t.Fatalf("%s was not stored in outputfile", k)
 		}
 
-		if actual != v.Value() {
+		if actual != v.String() {
 			t.Fatalf("value %s for %s expected, but found %s", v, k, actual)
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Refactoring output handling with the following goals:
* Removal of hardcoded output key values containing possible multi line strings for certain CI platforms. e.g `payload`
* Separation of output values for stdout vs platform outputs. (github, gitlab)

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
