### PR TITLE
add 'policy_soft_failed' to desired status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 ## Bug Fixes
+* Fixes issue with runs incorrectly marked as `Error` when status ends in `policy_soft_failed` by @mjyocca [#23](https://github.com/hashicorp/tfc-workflows-tooling/pull/23)
 
 # v1.0.2
 

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -42,7 +42,6 @@ var NoopStatus = []tfe.RunStatus{
 	tfe.RunErrored,
 	tfe.RunCanceled,
 	tfe.RunDiscarded,
-	tfe.RunPolicySoftFailed,
 	ForceCancel,
 	PrePlanAwaitingDecision,
 	PostPlanAwaitingDecision,
@@ -151,7 +150,12 @@ func (service *runService) CreateRun(ctx context.Context, options CreateRunOptio
 
 		log.Printf("[DEBUG] PlanOnly: %t, CostEstimation: %t, PolicyChecks: %t", r.PlanOnly, costEstimateEnabled, policyChecksEnabled)
 
-		desiredStatus := []tfe.RunStatus{tfe.RunPlannedAndFinished, tfe.RunApplied}
+		desiredStatus := []tfe.RunStatus{
+			tfe.RunPolicySoftFailed,
+			tfe.RunPlannedAndFinished,
+			tfe.RunApplied,
+		}
+
 		if !r.PlanOnly {
 			if costEstimateEnabled && !policyChecksEnabled {
 				desiredStatus = append(desiredStatus, tfe.RunCostEstimated)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Add `policy_soft_failed` status to desired status slice to be treated as `Success`. 

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
