### PR TITLE
Fix unreached sentinel policies blocking log read to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bug Fixes
 * Fixes issue with runs incorrectly marked as `Error` when status ends in `policy_soft_failed` by @mjyocca [#23](https://github.com/hashicorp/tfc-workflows-tooling/pull/23)
+* Fixes bug with reading logs from unreached sentinel policies blocking the main go-routine by @mjyocca [#24](https://github.com/hashicorp/tfc-workflows-tooling/pull/24)
 
 # v1.0.2
 

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -311,9 +311,12 @@ func (service *runService) CancelRun(ctx context.Context, options CancelRunOptio
 }
 
 func (service *runService) GetPlanLogs(ctx context.Context, planID string) error {
+	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+
 	var err error
 	var logReader io.Reader
-	logReader, err = service.tfe.Plans.Logs(ctx, planID)
+	logReader, err = service.tfe.Plans.Logs(ctxTimeout, planID)
 	if err != nil {
 		return err
 	}
@@ -328,9 +331,12 @@ func (service *runService) GetPlanLogs(ctx context.Context, planID string) error
 }
 
 func (service *runService) GetApplyLogs(ctx context.Context, applyID string) error {
+	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+
 	var err error
 	var logReader io.Reader
-	logReader, err = service.tfe.Applies.Logs(ctx, applyID)
+	logReader, err = service.tfe.Applies.Logs(ctxTimeout, applyID)
 	if err != nil {
 		return err
 	}

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -16,6 +16,8 @@ import (
 	"github.com/sethvargo/go-retry"
 )
 
+const LogTimeout = time.Second * 10
+
 var (
 	ForceCancel              = tfe.RunStatus("force_canceled")
 	PrePlanAwaitingDecision  = tfe.RunStatus("pre_apply_awaiting_decision")
@@ -311,7 +313,7 @@ func (service *runService) CancelRun(ctx context.Context, options CancelRunOptio
 }
 
 func (service *runService) GetPlanLogs(ctx context.Context, planID string) error {
-	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctxTimeout, cancel := context.WithTimeout(ctx, LogTimeout)
 	defer cancel()
 
 	var err error
@@ -331,7 +333,7 @@ func (service *runService) GetPlanLogs(ctx context.Context, planID string) error
 }
 
 func (service *runService) GetApplyLogs(ctx context.Context, applyID string) error {
-	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctxTimeout, cancel := context.WithTimeout(ctx, LogTimeout)
 	defer cancel()
 
 	var err error

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -438,21 +438,14 @@ func (s *runService) LogTaskStage(ctx context.Context, run *tfe.Run, stage tfe.S
 }
 
 func (s *runService) LogCostEstimation(ctx context.Context, run *tfe.Run) {
-	checkStatus := func(s tfe.CostEstimateStatus) bool {
-		for _, status := range []tfe.CostEstimateStatus{tfe.CostEstimateStatus("unreachable"), tfe.CostEstimatePending} {
-			if s == status {
-				return false
-			}
-		}
-		return true
+	if run.CostEstimate == nil || run.CostEstimate.Status == tfe.CostEstimateStatus("unreachable") || run.CostEstimate.Status == tfe.CostEstimatePending {
+		return
 	}
 
-	if run.CostEstimate != nil && checkStatus(run.CostEstimate.Status) {
-		fmt.Printf("\n-------------- CostEstimation (%s) --------------\n", run.CostEstimate.ID)
-		fmt.Printf("Status: '%s', ErrorMessage: '%s'\n", run.CostEstimate.Status, run.CostEstimate.ErrorMessage)
-		fmt.Printf("PriorMonthlyCost: (%s), ProposedMonthlyCost: (%s), Delta: (%s)\n", run.CostEstimate.PriorMonthlyCost, run.CostEstimate.ProposedMonthlyCost, run.CostEstimate.DeltaMonthlyCost)
-		fmt.Println()
-	}
+	fmt.Printf("\n-------------- CostEstimation (%s) --------------\n", run.CostEstimate.ID)
+	fmt.Printf("Status: '%s', ErrorMessage: '%s'\n", run.CostEstimate.Status, run.CostEstimate.ErrorMessage)
+	fmt.Printf("PriorMonthlyCost: (%s), ProposedMonthlyCost: (%s), Delta: (%s)\n", run.CostEstimate.PriorMonthlyCost, run.CostEstimate.ProposedMonthlyCost, run.CostEstimate.DeltaMonthlyCost)
+	fmt.Println()
 }
 
 func outputRunLogLines(logs io.Reader) error {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

* Fix issue with attempting to read sentinel policy logs that never ran from blocking execution.
* Only log to stdout cost estimation / sentinel policies that have ran.


## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
