### PR TITLE
Add workspace output list command

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -78,6 +78,9 @@ func newCliRunner() (*cli.CLI, error) {
 		"plan output": func() (cli.Command, error) {
 			return &command.OutputPlanCommand{Meta: meta}, nil
 		},
+		"workspace output list": func() (cli.Command, error) {
+			return &command.WorkspaceOutputCommand{Meta: meta}, nil
+		},
 	}
 
 	return cliRunner, nil

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -11,6 +11,7 @@ type Cloud struct {
 	ConfigVersionService
 	RunService
 	PlanService
+	WorkspaceService
 }
 
 func NewCloud(c *tfe.Client) *Cloud {
@@ -18,5 +19,6 @@ func NewCloud(c *tfe.Client) *Cloud {
 		ConfigVersionService: NewConfigVersionService(c),
 		RunService:           NewRunService(c),
 		PlanService:          NewPlanService(c),
+		WorkspaceService:     NewWorkspaceService(c),
 	}
 }

--- a/internal/cloud/workspace.go
+++ b/internal/cloud/workspace.go
@@ -49,11 +49,13 @@ func (s *workspaceService) ReadStateOutputs(ctx context.Context, orgName string,
 	if !currentSV.ResourcesProcessed {
 		retryErr := retry.Do(ctx, wServiceBackoff(), func(ctx context.Context) error {
 			currentSV, csvErr = s.tfe.StateVersions.ReadCurrent(ctx, w.ID)
-			if currentSV.ResourcesProcessed {
-				return nil
-			}
+			// return non-retryable error
 			if csvErr != nil {
 				return csvErr
+			}
+			// keep checking until resources have been processed
+			if currentSV.ResourcesProcessed {
+				return nil
 			}
 			return retryableTimeoutError("workspace output list")
 		})

--- a/internal/cloud/workspace.go
+++ b/internal/cloud/workspace.go
@@ -1,0 +1,75 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/sethvargo/go-retry"
+)
+
+type WorkspaceService interface {
+	ReadStateOutputs(context.Context, string, string) (*tfe.StateVersionOutputsList, error)
+}
+
+type workspaceService struct {
+	tfe *tfe.Client
+}
+
+func wServiceBackoff() retry.Backoff {
+	backoff := retry.NewFibonacci(2 * time.Second)
+	backoff = retry.WithCappedDuration(7*time.Second, backoff)
+	backoff = retry.WithMaxDuration(5*time.Minute, backoff)
+	return backoff
+}
+
+func (s *workspaceService) ReadStateOutputs(ctx context.Context, orgName string, wName string) (*tfe.StateVersionOutputsList, error) {
+	w, wErr := s.tfe.Workspaces.Read(ctx, orgName, wName)
+	if wErr != nil {
+		return nil, wErr
+	}
+
+	if w.ID == "" {
+		return nil, fmt.Errorf("unable to find workspace by provided name: '%s'", wName)
+	}
+
+	currentSV, csvErr := s.tfe.StateVersions.ReadCurrent(ctx, w.ID)
+	if csvErr != nil {
+		return nil, csvErr
+	}
+
+	// if current state version hasn;t been processed yet,
+	// retry/wait until processed or timeout
+	if !currentSV.ResourcesProcessed {
+		//implement retry
+		retryErr := retry.Do(ctx, wServiceBackoff(), func(ctx context.Context) error {
+			currentSV, csvErr = s.tfe.StateVersions.ReadCurrent(ctx, w.ID)
+			if currentSV.ResourcesProcessed {
+				return nil
+			}
+			if csvErr != nil {
+				return csvErr
+			}
+			return retryableTimeoutError("workspace output list")
+		})
+
+		if retryErr != nil {
+			return nil, retryErr
+		}
+	}
+
+	svoList, svoErr := s.tfe.StateVersionOutputs.ReadCurrent(ctx, w.ID)
+	if svoErr != nil {
+		return nil, svoErr
+	}
+
+	return svoList, svoErr
+}
+
+func NewWorkspaceService(tfe *tfe.Client) *workspaceService {
+	return &workspaceService{tfe}
+}

--- a/internal/cloud/workspace.go
+++ b/internal/cloud/workspace.go
@@ -34,7 +34,7 @@ func wServiceBackoff() retry.Backoff {
 func (s *workspaceService) ReadStateOutputs(ctx context.Context, orgName string, wName string) (*tfe.StateVersionOutputsList, error) {
 	w, wErr := s.tfe.Workspaces.Read(ctx, orgName, wName)
 	if wErr != nil {
-		log.Printf("[ERROR] error reading workspace: '%s' in organization: '%s', with: %s", wName, orgName, wErr)
+		log.Printf("[ERROR] error reading workspace: %q organization: %q, error: %s", wName, orgName, wErr)
 		return nil, wErr
 	}
 
@@ -59,7 +59,7 @@ func (s *workspaceService) ReadStateOutputs(ctx context.Context, orgName string,
 		})
 
 		if retryErr != nil {
-			log.Printf("[ERROR] error waiting for current state version to finish processing")
+			log.Printf("[ERROR] error waiting for current state version to finish processing: %s", retryErr)
 			return nil, retryErr
 		}
 	}

--- a/internal/cloud/workspace_test.go
+++ b/internal/cloud/workspace_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloud
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe/mocks"
+)
+
+func TestWorkspaceService_ReadStateOutputs(t *testing.T) {
+
+	testCases := []struct {
+		name                   string
+		orgName                string
+		workspaceName          string
+		ctx                    context.Context
+		workspaceID            string
+		tfeWorkspace           *tfe.Workspace
+		tfeStateVersion        *tfe.StateVersion
+		tfeStateVersionOutputs *tfe.StateVersionOutputsList
+	}{
+		{
+			name:          "basic",
+			orgName:       "abc-company",
+			workspaceName: "my-workspace",
+			ctx:           context.Background(),
+			workspaceID:   "ws-***",
+			tfeWorkspace:  &tfe.Workspace{ID: "ws-***"},
+			tfeStateVersion: &tfe.StateVersion{
+				ResourcesProcessed: true,
+			},
+			tfeStateVersionOutputs: &tfe.StateVersionOutputsList{
+				Items: []*tfe.StateVersionOutput{{
+					Name:  "image_id",
+					Value: "ami-12345",
+				},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// mock workspace
+			mWorkspace := mocks.NewMockWorkspaces(ctrl)
+			mWorkspace.EXPECT().Read(tc.ctx, tc.orgName, tc.workspaceName).Return(
+				tc.tfeWorkspace,
+				nil,
+			)
+
+			// mock state version
+			mockStateVersion := mocks.NewMockStateVersions(ctrl)
+			mockStateVersion.EXPECT().ReadCurrent(tc.ctx, tc.workspaceID).Return(
+				tc.tfeStateVersion,
+				nil,
+			)
+
+			// mock state version output
+			mockStateVersionOutputList := mocks.NewMockStateVersionOutputs(ctrl)
+			mockStateVersionOutputList.EXPECT().ReadCurrent(tc.ctx, tc.workspaceID).Return(
+				tc.tfeStateVersionOutputs,
+				nil,
+			)
+
+			client := &workspaceService{
+				tfe: &tfe.Client{
+					Workspaces:          mWorkspace,
+					StateVersions:       mockStateVersion,
+					StateVersionOutputs: mockStateVersionOutputList,
+				},
+			}
+
+			result, resultErr := client.ReadStateOutputs(tc.ctx, tc.orgName, tc.workspaceName)
+
+			if resultErr != nil {
+				t.Fatalf("expected %v but received %s", nil, resultErr)
+			}
+
+			if !reflect.DeepEqual(result, tc.tfeStateVersionOutputs) {
+				t.Errorf("expected %v but received %v", result, tc.tfeStateVersionOutputs)
+			}
+		})
+	}
+}
+
+func TestWorkspaceService_ReadStateOutputs_Retry(t *testing.T) {
+	t.Run("test-retry-behavior", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx, orgName, workspaceName, wID := context.Background(), "test-org", "my-workspace", "ws-***"
+
+		tfeWorkspace := &tfe.Workspace{ID: wID}
+		tfeStateVersion := &tfe.StateVersion{
+			ResourcesProcessed: false,
+		}
+		tfeStateVersionOutputs := &tfe.StateVersionOutputsList{
+			Items: []*tfe.StateVersionOutput{{
+				Name:  "image_id",
+				Value: "ami-12345",
+			},
+			},
+		}
+
+		// mock workspace
+		mWorkspace := mocks.NewMockWorkspaces(ctrl)
+		mWorkspace.EXPECT().Read(ctx, orgName, workspaceName).Return(
+			tfeWorkspace,
+			nil,
+		)
+
+		// mock state version
+		mockStateVersion := mocks.NewMockStateVersions(ctrl)
+		// Assert and mock retry with resources processed set to false
+		retryCall := mockStateVersion.EXPECT().ReadCurrent(ctx, wID).Return(tfeStateVersion, nil).Times(3)
+		// Assert and mock retry is stopped when resources processed is set to true
+		doneCall := mockStateVersion.EXPECT().ReadCurrent(ctx, wID).Return(&tfe.StateVersion{
+			ResourcesProcessed: true,
+		}, nil)
+
+		// Expect retry calls before done call
+		gomock.InOrder(
+			retryCall,
+			doneCall,
+		)
+
+		mockStateVersionOutputList := mocks.NewMockStateVersionOutputs(ctrl)
+		mockStateVersionOutputList.EXPECT().ReadCurrent(ctx, wID).Return(
+			tfeStateVersionOutputs,
+			nil,
+		)
+
+		client := &workspaceService{
+			tfe: &tfe.Client{
+				Workspaces:          mWorkspace,
+				StateVersions:       mockStateVersion,
+				StateVersionOutputs: mockStateVersionOutputList,
+			},
+		}
+
+		// invoke workspace service call
+		client.ReadStateOutputs(ctx, orgName, workspaceName)
+	})
+}

--- a/internal/cloud/workspace_test.go
+++ b/internal/cloud/workspace_test.go
@@ -36,10 +36,11 @@ func TestWorkspaceService_ReadStateOutputs(t *testing.T) {
 				ResourcesProcessed: true,
 			},
 			tfeStateVersionOutputs: &tfe.StateVersionOutputsList{
-				Items: []*tfe.StateVersionOutput{{
-					Name:  "image_id",
-					Value: "ami-12345",
-				},
+				Items: []*tfe.StateVersionOutput{
+					{
+						Name:  "image_id",
+						Value: "ami-12345",
+					},
 				},
 			},
 		},
@@ -104,10 +105,11 @@ func TestWorkspaceService_ReadStateOutputs_Retry(t *testing.T) {
 			ResourcesProcessed: false,
 		}
 		tfeStateVersionOutputs := &tfe.StateVersionOutputsList{
-			Items: []*tfe.StateVersionOutput{{
-				Name:  "image_id",
-				Value: "ami-12345",
-			},
+			Items: []*tfe.StateVersionOutput{
+				{
+					Name:  "image_id",
+					Value: "ami-12345",
+				},
 			},
 		}
 

--- a/internal/command/workspace_output.go
+++ b/internal/command/workspace_output.go
@@ -1,0 +1,103 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+)
+
+type WorkspaceOutputCommand struct {
+	*Meta
+
+	Workspace string
+}
+
+type WorkspaceOutput struct {
+	Name  string      `json:"name"`
+	Value interface{} `json:"value"`
+}
+
+func (c *WorkspaceOutputCommand) flags() *flag.FlagSet {
+	f := c.flagSet("state output")
+	f.StringVar(&c.Workspace, "workspace", "", "The name of the Terraform Cloud Workspace.")
+
+	return f
+}
+
+func (c *WorkspaceOutputCommand) SetupCmd(args []string) (err error) {
+	flags := c.flags()
+	if err = flags.Parse(args); err != nil {
+		c.addOutput("status", string(Error))
+		c.closeOutput()
+		c.Ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		return err
+	}
+	return
+}
+
+func (c *WorkspaceOutputCommand) Run(args []string) int {
+	if err := c.SetupCmd(args); err != nil {
+		return 1
+	}
+
+	// validate workspace name was supplied as argument
+	if c.Workspace == "" {
+		c.addOutput("status", string(Error))
+		c.closeOutput()
+		c.Ui.Error("error workspace output list requires a workspace name")
+		return 1
+	}
+
+	svoList, svoErr := c.cloud.ReadStateOutputs(c.Context, c.Organization, c.Workspace)
+	if svoErr != nil {
+		status := c.resolveStatus(svoErr)
+		c.addOutput("status", string(status))
+		c.closeOutput()
+		c.Ui.Error(fmt.Sprintf("error retrieving workspace state version outputs: %s\n", svoErr.Error()))
+		return 1
+	}
+
+	workspaceOutputs := []*WorkspaceOutput{}
+	for _, svo := range svoList.Items {
+		workspaceOutputs = append(workspaceOutputs, &WorkspaceOutput{
+			Name:  svo.Name,
+			Value: svo.Value,
+		})
+	}
+
+	c.addOutputWithOpts("outputs", workspaceOutputs, &outputOpts{
+		stdOut:    true,
+		multiLine: true,
+	})
+	c.addOutput("status", string(Success))
+	c.Ui.Output(c.closeOutput())
+	return 0
+}
+
+func (c *WorkspaceOutputCommand) Help() string {
+	helpText := `
+Usage: tfci [global options] workspace outputs [options]
+
+	Returns current state version outputs for a workspace.
+
+Global Options:
+
+	-hostname       The hostname of a Terraform Enterprise installation, if using Terraform Enterprise. Defaults to "app.terraform.io".
+
+	-token          The token used to authenticate with Terraform Cloud. Defaults to reading "TF_API_TOKEN" environment variable.
+
+	-organization   Terraform Cloud Organization Name.
+
+Options:
+
+	-workspace            Existing Terraform Cloud Workspace.
+	`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *WorkspaceOutputCommand) Synopsis() string {
+	return "Returns current state version outputs for a workspace."
+}

--- a/internal/command/workspace_output_test.go
+++ b/internal/command/workspace_output_test.go
@@ -1,0 +1,185 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/tfci/internal/cloud"
+	"github.com/hashicorp/tfci/internal/environment"
+	"github.com/mitchellh/cli"
+)
+
+type WorkspaceOutputReader struct {
+	svo *tfe.StateVersionOutputsList
+}
+
+func (w *WorkspaceOutputReader) ReadStateOutputs(_ context.Context, orgName string, wName string) (*tfe.StateVersionOutputsList, error) {
+	return w.svo, nil
+}
+
+type testWorkspaceOutputCommandOpts struct {
+	items []*tfe.StateVersionOutput
+}
+
+func testWorkspaceOutputCommand(t *testing.T, opts *testWorkspaceOutputCommandOpts) (*cli.MockUi, *WorkspaceOutputCommand) {
+	t.Helper()
+
+	if opts.items == nil || len(opts.items) < 1 {
+		opts.items = []*tfe.StateVersionOutput{{
+			Name:      "test",
+			Value:     "",
+			Sensitive: false,
+		}}
+	}
+
+	cloudMockService := &cloud.Cloud{
+		WorkspaceService: &WorkspaceOutputReader{
+			svo: &tfe.StateVersionOutputsList{
+				Items: opts.items,
+			},
+		},
+	}
+	ui := cli.NewMockUi()
+	meta := NewMeta(cloudMockService)
+	meta.Ui = ui
+	meta.Env = &environment.CI{}
+
+	return ui, &WorkspaceOutputCommand{Meta: meta}
+}
+
+func TestWorkspaceOutputListCommand_Output(t *testing.T) {
+	testCases := []struct {
+		name    string
+		args    []string
+		svoList []*tfe.StateVersionOutput
+	}{
+		{
+			name: "standard-values",
+			args: []string{"--workspace=my-workspace"},
+			svoList: []*tfe.StateVersionOutput{{
+				Name:  "image_id",
+				Value: "ami-123456",
+			},
+			},
+		},
+		{
+			name: "sensitive-values",
+			args: []string{"--workspace=my-workspace"},
+			svoList: []*tfe.StateVersionOutput{{
+				Name:      "db_creds",
+				Value:     "null",
+				Sensitive: true,
+			},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui, cmd := testWorkspaceOutputCommand(t, &testWorkspaceOutputCommandOpts{
+				items: tc.svoList,
+			})
+
+			code := cmd.Run(tc.args)
+			if code != 0 {
+				t.Fatalf("expected %d but received %d", 0, code)
+			}
+
+			stderr := ui.ErrorWriter.String()
+			if stderr != "" {
+				t.Fatalf("expected %q but received %q", "", stderr)
+			}
+
+			stdout := ui.OutputWriter.String()
+
+			var outputVal struct {
+				Outputs []WorkspaceOutput `json:"outputs"`
+				Status  string            `json:"status"`
+			}
+			json.Unmarshal([]byte(stdout), &outputVal)
+
+			for i, o := range outputVal.Outputs {
+				actualVal, _ := json.Marshal(o.Value)
+				expectVal, _ := json.Marshal(tc.svoList[i].Value)
+				if !strings.Contains(string(actualVal), string(expectVal)) {
+					t.Fatalf("expected %q but received %q", string(expectVal), string(actualVal))
+				}
+			}
+		})
+	}
+}
+
+func TestWorkspaceOutputListCommand_SuccessArgs(t *testing.T) {
+	testCases := []struct {
+		name       string
+		args       []string
+		exitStatus int
+	}{
+		{
+			name:       "valid-args",
+			args:       []string{"--workspace", "my-workspace"},
+			exitStatus: 0,
+		},
+		{
+			name:       "valid-args-equal",
+			args:       []string{"--workspace=my-workspace"},
+			exitStatus: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			_, cmd := testWorkspaceOutputCommand(t, &testWorkspaceOutputCommandOpts{})
+
+			if actual := cmd.Run(tc.args); actual != tc.exitStatus {
+				t.Errorf("WorkspaceOutputs (%s), expected: %v, actual: %v", tc.name, tc.exitStatus, actual)
+			}
+		})
+	}
+}
+
+func TestWorkspaceOutputListCommand_ErrorArgs(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []string
+		errorMessage string
+	}{
+		{
+			name:         "invalid-args",
+			args:         []string{"-workspace"},
+			errorMessage: "error parsing command-line flags: flag needs an argument: -workspace",
+		},
+		{
+			name:         "no-args",
+			args:         []string{""},
+			errorMessage: "error workspace output list requires a workspace name",
+		},
+		{
+			name:         "supported-and-unsupported-args",
+			args:         []string{"--workspace=my-workspace", "--unknown"},
+			errorMessage: "error parsing command-line flags: flag provided but not defined: -unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			ui, cmd := testWorkspaceOutputCommand(t, &testWorkspaceOutputCommandOpts{})
+			// run cmd
+			cmd.Run(tc.args)
+
+			output := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+			if !strings.Contains(output, tc.errorMessage) {
+				t.Errorf("expected %q but received %q", tc.errorMessage, output)
+			}
+		})
+	}
+}

--- a/internal/command/workspace_output_test.go
+++ b/internal/command/workspace_output_test.go
@@ -31,11 +31,13 @@ func testWorkspaceOutputCommand(t *testing.T, opts *testWorkspaceOutputCommandOp
 	t.Helper()
 
 	if opts.items == nil || len(opts.items) < 1 {
-		opts.items = []*tfe.StateVersionOutput{{
-			Name:      "test",
-			Value:     "",
-			Sensitive: false,
-		}}
+		opts.items = []*tfe.StateVersionOutput{
+			{
+				Name:      "test",
+				Value:     "",
+				Sensitive: false,
+			},
+		}
 	}
 
 	cloudMockService := &cloud.Cloud{
@@ -62,20 +64,22 @@ func TestWorkspaceOutputListCommand_Output(t *testing.T) {
 		{
 			name: "standard-values",
 			args: []string{"--workspace=my-workspace"},
-			svoList: []*tfe.StateVersionOutput{{
-				Name:  "image_id",
-				Value: "ami-123456",
-			},
+			svoList: []*tfe.StateVersionOutput{
+				{
+					Name:  "image_id",
+					Value: "ami-123456",
+				},
 			},
 		},
 		{
 			name: "sensitive-values",
 			args: []string{"--workspace=my-workspace"},
-			svoList: []*tfe.StateVersionOutput{{
-				Name:      "db_creds",
-				Value:     "null",
-				Sensitive: true,
-			},
+			svoList: []*tfe.StateVersionOutput{
+				{
+					Name:      "db_creds",
+					Value:     "null",
+					Sensitive: true,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Adds new `workspace output list` command. 

#### Arguments
* `--workspace` name of the existing Terraform Cloud workspace.

#### Returns
* `outputs`[] json array consisting of current outputs for the provided Terraform Cloud workspace. (sensitive values are returned as `null`)
* `status` of the operation.

#### Related Issues
* #9 

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
