### PR TITLE
Fix missing default for platformOut option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # UNRELEASED
 
 ## Enhancements
+* Adds new command, `workspace output list` to retrieve outputs for an existing Terraform Cloud workspace by @mjyocca [#29](https://github.com/hashicorp/tfc-workflows-tooling/pull/29)
 
 ## Bug Fixes
+* Fixes issue with `payload` output missing from `run create`, `run show`, `upload`, `plan output` commands by @mjyocca [#46](https://github.com/hashicorp/tfc-workflows-tooling/pull/46)
 
 # v1.0.3
 

--- a/internal/command/plan_output.go
+++ b/internal/command/plan_output.go
@@ -59,8 +59,9 @@ func (c *OutputPlanCommand) addPlanDetails(plan *tfe.Plan) {
 	c.addOutput("destroy", fmt.Sprint(plan.ResourceDestructions))
 
 	c.addOutputWithOpts("payload", plan, &outputOpts{
-		stdOut:    false,
-		multiLine: true,
+		stdOut:      false,
+		multiLine:   true,
+		platformOut: true,
 	})
 }
 

--- a/internal/command/run_create.go
+++ b/internal/command/run_create.go
@@ -103,8 +103,9 @@ func (c *CreateRunCommand) addRunDetails(run *tfe.Run) {
 	}
 
 	c.addOutputWithOpts("payload", run, &outputOpts{
-		stdOut:    false,
-		multiLine: true,
+		stdOut:      false,
+		multiLine:   true,
+		platformOut: true,
 	})
 }
 

--- a/internal/command/run_show.go
+++ b/internal/command/run_show.go
@@ -86,8 +86,9 @@ func (c *ShowRunCommand) addRunDetails(run *tfe.Run) {
 	}
 
 	c.addOutputWithOpts("payload", run, &outputOpts{
-		stdOut:    false,
-		multiLine: true,
+		stdOut:      false,
+		multiLine:   true,
+		platformOut: true,
 	})
 }
 

--- a/internal/command/upload.go
+++ b/internal/command/upload.go
@@ -81,8 +81,9 @@ func (c *UploadConfigurationCommand) addConfigurationDetails(config *tfe.Configu
 	}
 
 	c.addOutputWithOpts("payload", config, &outputOpts{
-		stdOut:    false,
-		multiLine: true,
+		stdOut:      false,
+		multiLine:   true,
+		platformOut: true,
 	})
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Fixes Issue #45  that was introduced in [v1.0.3](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.0.3). 

Missed instances of zero value for bool field when adding artifact to output.

### Plan
- Merge this fix into main
- Back-port and patch a release for v1.0.4 since main includes new additions for next minor release

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
