### PR TITLE
Instructions for use with Terraform Enterprise Added to USAGE.md

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -95,3 +95,32 @@ docker run -it \
   hashicorp/tfci:latest \
   tfci run show --help
 ```
+
+## Usage with Terraform Enterprise
+If Terraform Enterprise is using TLS certificates signed by a private CA build a custom image.
+
+1. Create a directroy named `docker-tfci-custom`
+2. Change into that directory
+3. Create a file in that directory named `Dockerfile`
+4. Add the following and substitute `/path/to/ca.crt` for the path to your CA certificate:
+
+```dockerfile
+FROM hashicorp/tfci:latest
+COPY /path/to/ca.crt /usr/local/share/ca-certificates/
+RUN apk --no-cache add ca-certificates
+RUN update-ca-certificates
+```
+
+5. Build the image from the docker file like so replacing `registry.example.com/namespace` with your container registries address and namespace and whatever you wish to name the container.
+
+```sh
+docker build -t registry.example.com/namespace/tfci-custom .
+```
+
+> Note: If you are using GitLab as your container registry see [Naming Convention for Container Images](https://docs.gitlab.com/ee/user/packages/container_registry/#naming-convention-for-your-container-images)
+
+Push the custom container to your container registry like so
+
+```sh
+docker push registry.example.com/namespace/tfci-custom
+```


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Terraform Enterprise owners usually sign Terraform Enterprise TLS certificates with a private CA. Attempting to use tfci to interact with a Terraform Enterprise API in this way will cause an x509 error. A custom container image can be built from the hashicorp/tfci container with the CA certificate included to enable trust between the tfci container running in the pipelines and Terraform Enterprise.

## Testing plan

1. Create a Terraform Enterprise server signed by a private CA or self signed certificate
2. Create a custom image from the hashicorp/tfci container and provide the CA certificate
3. Run the tfci container and attempt to interact with the Terraform Enterprise API

## External links
