### PR TITLE
fix: Prevent Auto-Apply TFC workspaces from exiting early for `run create` cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## Bug Fixes
 * Fixes issue with `payload` output missing from `run create`, `run show`, `upload`, `plan output` commands by @mjyocca [#46](https://github.com/hashicorp/tfc-workflows-tooling/pull/46)
+* Fixes race condition with the `run create` command when an `auto-apply` configured TFC/TFE workspace exits too soon by @mjyocca [#55](https://github.com/hashicorp/tfc-workflows-tooling/pull/55)
+
+# v1.0.4 (patch-v1.0.4)
+
+## Bug Fixes
+* Fixes issue with `payload` output missing from `run create`, `run show`, `upload`, `plan output` commands by @mjyocca [#46](https://github.com/hashicorp/tfc-workflows-tooling/pull/46)
 
 # v1.0.3
 

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -515,7 +515,7 @@ func getDesiredRunStatus(run *tfe.Run, policyChecksEnabled bool, costEstimateEna
 	// when auto_apply run
 	if run.AutoApply {
 		if policyChecksEnabled {
-			// policy override requies human approval before proceeding, run has reached no-op
+			// policy override requires human approval before proceeding, run has reached no-op
 			desiredStatus = append(desiredStatus, tfe.RunPolicyOverride)
 		}
 		return desiredStatus
@@ -523,14 +523,12 @@ func getDesiredRunStatus(run *tfe.Run, policyChecksEnabled bool, costEstimateEna
 
 	// when applyable/confirmable run
 	// determine which various run status it can end with
-	if !run.PlanOnly && !run.AutoApply {
-		if costEstimateEnabled && !policyChecksEnabled {
-			desiredStatus = append(desiredStatus, tfe.RunCostEstimated)
-		} else if policyChecksEnabled {
-			desiredStatus = append(desiredStatus, tfe.RunPolicyChecked, tfe.RunPolicyOverride)
-		} else {
-			desiredStatus = append(desiredStatus, tfe.RunPlanned)
-		}
+	if costEstimateEnabled && !policyChecksEnabled {
+		desiredStatus = append(desiredStatus, tfe.RunCostEstimated)
+	} else if policyChecksEnabled {
+		desiredStatus = append(desiredStatus, tfe.RunPolicyChecked, tfe.RunPolicyOverride)
+	} else {
+		desiredStatus = append(desiredStatus, tfe.RunPlanned)
 	}
 
 	return desiredStatus

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -524,10 +524,15 @@ func getDesiredRunStatus(run *tfe.Run, policyChecksEnabled bool, costEstimateEna
 	// when applyable/confirmable run
 	// determine which various run status it can end with
 	if costEstimateEnabled && !policyChecksEnabled {
+		// cost_estimation executes prior to sentinel policies
+		// if we expect `"cost_estimated"` as a final step, the cmd will eject too early
 		desiredStatus = append(desiredStatus, tfe.RunCostEstimated)
 	} else if policyChecksEnabled {
+		// account for `"policy_checked"` & `"policy_override"` if policy checks are enabled for the run
 		desiredStatus = append(desiredStatus, tfe.RunPolicyChecked, tfe.RunPolicyOverride)
 	} else {
+		// applyable/confirmable run has no cost estimation nor sentinel policies
+		// run task stages are accounted for in the Noop RunStatus slice
 		desiredStatus = append(desiredStatus, tfe.RunPlanned)
 	}
 

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -508,14 +508,14 @@ func getDesiredRunStatus(run *tfe.Run, policyChecksEnabled bool, costEstimateEna
 	// when plan_only run
 	if run.PlanOnly {
 		// plan only runs will result in default desired slice
-		// most likely planned_and_finsiehd or policy set failure
+		// most likely planned_and_finished or policy_soft_failed
 		return desiredStatus
 	}
 
 	// when auto_apply run
 	if run.AutoApply {
 		if policyChecksEnabled {
-			// policy override requies human approval, run has reached no-op
+			// policy override requies human approval before proceeding, run has reached no-op
 			desiredStatus = append(desiredStatus, tfe.RunPolicyOverride)
 		}
 		return desiredStatus

--- a/internal/cloud/run_test.go
+++ b/internal/cloud/run_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package cloud
 
 import (

--- a/internal/cloud/run_test.go
+++ b/internal/cloud/run_test.go
@@ -103,7 +103,12 @@ func TestRunService_CreateRun(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		// reassign loop variable to prevent scope capture
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			// allow these test cases to run in parallel
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 

--- a/internal/cloud/run_test.go
+++ b/internal/cloud/run_test.go
@@ -1,0 +1,153 @@
+package cloud
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe/mocks"
+)
+
+func TestRunService_CreateRun(t *testing.T) {
+	testCases := []struct {
+		name             string
+		orgName          string
+		workspaceName    string
+		ctx              context.Context
+		tfeWorkspace     *tfe.Workspace
+		tfeConfigVersion *tfe.ConfigurationVersion
+		tfeRun           *tfe.Run
+		statusChanges    []tfe.RunStatus
+		finalStatus      tfe.RunStatus
+	}{
+		{
+			name:          "plan-only-run",
+			orgName:       "test",
+			workspaceName: "my-workspace",
+			ctx:           context.Background(),
+			tfeWorkspace:  &tfe.Workspace{ID: "ws-***"},
+			tfeConfigVersion: &tfe.ConfigurationVersion{
+				ID:     "cv-***",
+				Status: tfe.ConfigurationUploaded,
+			},
+			tfeRun: &tfe.Run{
+				ID:       "run-***",
+				PlanOnly: true,
+			},
+			statusChanges: []tfe.RunStatus{
+				tfe.RunPlanning,
+				tfe.RunPlanning,
+				tfe.RunCostEstimated,
+				tfe.RunPolicyChecked,
+			},
+			finalStatus: tfe.RunPlannedAndFinished,
+		},
+		{
+			name:          "auto-apply-run",
+			orgName:       "test",
+			workspaceName: "my-workspace",
+			ctx:           context.Background(),
+			tfeWorkspace:  &tfe.Workspace{ID: "ws-***"},
+			tfeConfigVersion: &tfe.ConfigurationVersion{
+				ID:     "cv-***",
+				Status: tfe.ConfigurationUploaded,
+			},
+			tfeRun: &tfe.Run{
+				ID:        "run-***",
+				AutoApply: true,
+				CostEstimate: &tfe.CostEstimate{
+					ID: "cost-******",
+				},
+				PolicyChecks: []*tfe.PolicyCheck{
+					{ID: "pol-****"},
+				},
+			},
+			statusChanges: []tfe.RunStatus{
+				tfe.RunPlanning,
+				tfe.RunPlanning,
+				tfe.RunCostEstimated,
+				tfe.RunPolicyChecked,
+			},
+			finalStatus: tfe.RunApplied,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// mock workspace service
+			workspaceMock := mocks.NewMockWorkspaces(ctrl)
+			workspaceMock.EXPECT().Read(tc.ctx, tc.orgName, tc.workspaceName).Return(
+				tc.tfeWorkspace,
+				nil,
+			)
+			// mock configuration service
+			configVersionMock := mocks.NewMockConfigurationVersions(ctrl)
+			configVersionMock.EXPECT().Read(tc.ctx, tc.tfeConfigVersion.ID).Return(
+				tc.tfeConfigVersion,
+				nil,
+			)
+
+			// mock runs service
+			runMessage := ""
+			runsMock := mocks.NewMockRuns(ctrl)
+			runsMock.EXPECT().Create(tc.ctx, tfe.RunCreateOptions{
+				ConfigurationVersion: tc.tfeConfigVersion,
+				Workspace:            tc.tfeWorkspace,
+				PlanOnly:             tfe.Bool(tc.tfeRun.PlanOnly),
+				Message:              &runMessage,
+				Variables:            []*tfe.RunVariable{},
+			}).Return(tc.tfeRun, nil)
+
+			//
+			goMockCalls := []*gomock.Call{}
+			for _, status := range tc.statusChanges {
+				call := runsMock.EXPECT().ReadWithOptions(
+					tc.ctx,
+					tc.tfeRun.ID,
+					&tfe.RunReadOptions{Include: []tfe.RunIncludeOpt{"cost_estimate", "plan"}}).Return(&tfe.Run{
+					ID:     tc.tfeRun.ID,
+					Status: status,
+				}, nil)
+				goMockCalls = append(goMockCalls, call)
+			}
+
+			doneCall := runsMock.EXPECT().ReadWithOptions(tc.ctx, tc.tfeRun.ID, &tfe.RunReadOptions{
+				Include: []tfe.RunIncludeOpt{"cost_estimate", "plan"},
+			}).Return(&tfe.Run{
+				ID:     tc.tfeRun.ID,
+				Status: tc.finalStatus,
+			}, nil)
+			goMockCalls = append(goMockCalls, doneCall)
+
+			// Verify retry order behavior
+			gomock.InOrder(
+				goMockCalls...,
+			)
+
+			client := &runService{
+				tfe: &tfe.Client{
+					Workspaces:            workspaceMock,
+					ConfigurationVersions: configVersionMock,
+					Runs:                  runsMock,
+				},
+			}
+
+			_, err := client.CreateRun(tc.ctx, CreateRunOptions{
+				Organization:           tc.orgName,
+				ConfigurationVersionID: tc.tfeConfigVersion.ID,
+				Workspace:              tc.workspaceName,
+				Message:                "",
+				PlanOnly:               tc.tfeRun.PlanOnly,
+				RunVariables:           []*tfe.RunVariable{},
+			})
+
+			if err != nil {
+				t.Fatalf("expected %v but received %s", nil, err)
+			}
+		})
+	}
+}

--- a/internal/cloud/run_test.go
+++ b/internal/cloud/run_test.go
@@ -71,6 +71,32 @@ func TestRunService_CreateRun(t *testing.T) {
 			},
 			finalStatus: tfe.RunApplied,
 		},
+		{
+			name:          "confirmable-run",
+			orgName:       "test",
+			workspaceName: "my-workspace",
+			ctx:           context.Background(),
+			tfeWorkspace:  &tfe.Workspace{ID: "ws-***"},
+			tfeConfigVersion: &tfe.ConfigurationVersion{
+				ID:     "cv-***",
+				Status: tfe.ConfigurationUploaded,
+			},
+			tfeRun: &tfe.Run{
+				ID: "run-***",
+				CostEstimate: &tfe.CostEstimate{
+					ID: "cost-******",
+				},
+				PolicyChecks: []*tfe.PolicyCheck{
+					{ID: "pol-****"},
+				},
+			},
+			statusChanges: []tfe.RunStatus{
+				tfe.RunPlanning,
+				tfe.RunPlanned,
+				tfe.RunCostEstimated,
+			},
+			finalStatus: tfe.RunPolicyChecked,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/cloud/run_test.go
+++ b/internal/cloud/run_test.go
@@ -12,18 +12,46 @@ import (
 	"github.com/hashicorp/go-tfe/mocks"
 )
 
+type createRunTestCase struct {
+	name             string
+	orgName          string
+	workspaceName    string
+	ctx              context.Context
+	tfeWorkspace     *tfe.Workspace
+	tfeConfigVersion *tfe.ConfigurationVersion
+	tfeRun           *tfe.Run
+	statusChanges    []tfe.RunStatus
+	finalStatus      tfe.RunStatus
+}
+
+func testGenerateServiceMocks(t *testing.T, ctrl *gomock.Controller, tc createRunTestCase) (*mocks.MockWorkspaces, *mocks.MockConfigurationVersions, *mocks.MockRuns) {
+	// mock workspace service
+	workspaceMock := mocks.NewMockWorkspaces(ctrl)
+	workspaceMock.EXPECT().Read(tc.ctx, tc.orgName, tc.workspaceName).Return(
+		tc.tfeWorkspace,
+		nil,
+	)
+
+	configVersionMock := mocks.NewMockConfigurationVersions(ctrl)
+	configVersionMock.EXPECT().Read(tc.ctx, tc.tfeConfigVersion.ID).Return(
+		tc.tfeConfigVersion,
+		nil,
+	)
+
+	runsMock := mocks.NewMockRuns(ctrl)
+	runsMock.EXPECT().Create(tc.ctx, tfe.RunCreateOptions{
+		ConfigurationVersion: tc.tfeConfigVersion,
+		Workspace:            tc.tfeWorkspace,
+		PlanOnly:             tfe.Bool(tc.tfeRun.PlanOnly),
+		Message:              tfe.String(""),
+		Variables:            []*tfe.RunVariable{},
+	}).Return(tc.tfeRun, nil)
+
+	return workspaceMock, configVersionMock, runsMock
+}
+
 func TestRunService_CreateRun(t *testing.T) {
-	testCases := []struct {
-		name             string
-		orgName          string
-		workspaceName    string
-		ctx              context.Context
-		tfeWorkspace     *tfe.Workspace
-		tfeConfigVersion *tfe.ConfigurationVersion
-		tfeRun           *tfe.Run
-		statusChanges    []tfe.RunStatus
-		finalStatus      tfe.RunStatus
-	}{
+	testCases := []createRunTestCase{
 		{
 			name:          "plan-only-run",
 			orgName:       "test",
@@ -112,55 +140,35 @@ func TestRunService_CreateRun(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			// mock workspace service
-			workspaceMock := mocks.NewMockWorkspaces(ctrl)
-			workspaceMock.EXPECT().Read(tc.ctx, tc.orgName, tc.workspaceName).Return(
-				tc.tfeWorkspace,
-				nil,
-			)
-			// mock configuration service
-			configVersionMock := mocks.NewMockConfigurationVersions(ctrl)
-			configVersionMock.EXPECT().Read(tc.ctx, tc.tfeConfigVersion.ID).Return(
-				tc.tfeConfigVersion,
-				nil,
-			)
-
-			// mock runs service
-			runMessage := ""
-			runsMock := mocks.NewMockRuns(ctrl)
-			runsMock.EXPECT().Create(tc.ctx, tfe.RunCreateOptions{
-				ConfigurationVersion: tc.tfeConfigVersion,
-				Workspace:            tc.tfeWorkspace,
-				PlanOnly:             tfe.Bool(tc.tfeRun.PlanOnly),
-				Message:              &runMessage,
-				Variables:            []*tfe.RunVariable{},
-			}).Return(tc.tfeRun, nil)
-
-			//
 			goMockCalls := []*gomock.Call{}
+
+			readOptions := &tfe.RunReadOptions{
+				Include: []tfe.RunIncludeOpt{
+					"cost_estimate",
+					"plan",
+				},
+			}
+
+			// mock services
+			workspaceMock, configVersionMock, runsMock := testGenerateServiceMocks(t, ctrl, tc)
+
+			// mock and assert retry read behavior
 			for _, status := range tc.statusChanges {
-				call := runsMock.EXPECT().ReadWithOptions(
-					tc.ctx,
-					tc.tfeRun.ID,
-					&tfe.RunReadOptions{Include: []tfe.RunIncludeOpt{"cost_estimate", "plan"}}).Return(&tfe.Run{
+				call := runsMock.EXPECT().ReadWithOptions(tc.ctx, tc.tfeRun.ID, readOptions).Return(&tfe.Run{
 					ID:     tc.tfeRun.ID,
 					Status: status,
 				}, nil)
 				goMockCalls = append(goMockCalls, call)
 			}
 
-			doneCall := runsMock.EXPECT().ReadWithOptions(tc.ctx, tc.tfeRun.ID, &tfe.RunReadOptions{
-				Include: []tfe.RunIncludeOpt{"cost_estimate", "plan"},
-			}).Return(&tfe.Run{
+			doneCall := runsMock.EXPECT().ReadWithOptions(tc.ctx, tc.tfeRun.ID, readOptions).Return(&tfe.Run{
 				ID:     tc.tfeRun.ID,
 				Status: tc.finalStatus,
 			}, nil)
 			goMockCalls = append(goMockCalls, doneCall)
 
 			// Verify retry order behavior
-			gomock.InOrder(
-				goMockCalls...,
-			)
+			gomock.InOrder(goMockCalls...)
 
 			client := &runService{
 				tfe: &tfe.Client{


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

As reported by #49, prevent workspaces configured with `AutoApply` from exiting `create run` command too early. 

## Testing plan
- This is a hard scenario to replicate consistently. Best option is to vet any possible regressions.

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
