### PR TITLE
feat: allow global --json flag usage

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -67,7 +67,7 @@ func newCliRunner() (*cli.CLI, error) {
 		cloudService,
 		env,
 		cmd.WithOrg(*organizationFlag),
-		cmd.WithUi(Ui),
+		cmd.WithWriter(writer),
 	)
 
 	cliRunner.Commands = map[string]cli.CommandFactory{

--- a/cli.go
+++ b/cli.go
@@ -19,6 +19,7 @@ var (
 	hostnameFlag     = flag.String("hostname", "", "The hostname of a Terraform Enterprise installation, if using Terraform Enterprise. Defaults to Terraform Cloud (app.terraform.io)")
 	tokenFlag        = flag.String("token", "", "The token used to authenticate with Terraform Cloud. Defaults to reading `TF_API_TOKEN` environment variable")
 	organizationFlag = flag.String("organization", "", "Terraform Cloud Organization Name")
+	json             = flag.Bool("json", false, "")
 )
 
 func newCliRunner() (*cli.CLI, error) {
@@ -48,13 +49,16 @@ func newCliRunner() (*cli.CLI, error) {
 		return nil, err
 	}
 
-	c := cloud.NewCloud(tfe)
+	tfeClient := cloud.NewCloud(tfe)
 
-	meta := command.NewMeta(c)
-	meta.Ui = Ui
-	meta.Organization = *organizationFlag
-	meta.Context = appCtx
-	meta.Env = env
+	meta := command.NewMetaOpts(
+		appCtx,
+		tfeClient,
+		env,
+		command.WithOrg(*organizationFlag),
+		command.WithUi(Ui),
+		command.WithJson(*json),
+	)
 
 	cliRunner.Commands = map[string]cli.CommandFactory{
 		"upload": func() (cli.Command, error) {

--- a/cli.go
+++ b/cli.go
@@ -20,7 +20,6 @@ var (
 	hostnameFlag     = flag.String("hostname", "", "The hostname of a Terraform Enterprise installation, if using Terraform Enterprise. Defaults to Terraform Cloud (app.terraform.io)")
 	tokenFlag        = flag.String("token", "", "The token used to authenticate with Terraform Cloud. Defaults to reading `TF_API_TOKEN` environment variable")
 	organizationFlag = flag.String("organization", "", "Terraform Cloud Organization Name")
-	json             = flag.Bool("json", false, "Suppresses all logs and instead returns output value in JSON format")
 )
 
 func newCliRunner() (*cli.CLI, error) {
@@ -37,16 +36,7 @@ func newCliRunner() (*cli.CLI, error) {
 	cliRunner := cli.NewCLI("tfc", version.GetVersion())
 	cliRunner.Args = newArgs
 
-	// global check if --json flag has been passed
-	// otherwise can't determine flag until subcommand Run()s
-	for _, arg := range newArgs {
-		if arg == "-json" || arg == "--json" {
-			*json = true
-			continue
-		}
-	}
-
-	writer := writer.NewWriter(Ui, *json)
+	writer := writer.NewWriter(Ui)
 	orgEnv := os.Getenv("TF_CLOUD_ORGANIZATION")
 
 	if *organizationFlag == "" && orgEnv != "" {

--- a/cli.go
+++ b/cli.go
@@ -68,7 +68,6 @@ func newCliRunner() (*cli.CLI, error) {
 		env,
 		cmd.WithOrg(*organizationFlag),
 		cmd.WithWriter(writer),
-		// command.WithJson(*json),
 	)
 
 	cliRunner.Commands = map[string]cli.CommandFactory{

--- a/cli.go
+++ b/cli.go
@@ -67,7 +67,7 @@ func newCliRunner() (*cli.CLI, error) {
 		cloudService,
 		env,
 		cmd.WithOrg(*organizationFlag),
-		cmd.WithWriter(writer),
+		cmd.WithUi(Ui),
 	)
 
 	cliRunner.Commands = map[string]cli.CommandFactory{

--- a/cli.go
+++ b/cli.go
@@ -20,7 +20,7 @@ var (
 	hostnameFlag     = flag.String("hostname", "", "The hostname of a Terraform Enterprise installation, if using Terraform Enterprise. Defaults to Terraform Cloud (app.terraform.io)")
 	tokenFlag        = flag.String("token", "", "The token used to authenticate with Terraform Cloud. Defaults to reading `TF_API_TOKEN` environment variable")
 	organizationFlag = flag.String("organization", "", "Terraform Cloud Organization Name")
-	json             = flag.Bool("json", false, "")
+	json             = flag.Bool("json", false, "Suppresses all logs and instead returns output value in JSON format")
 )
 
 func newCliRunner() (*cli.CLI, error) {

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -7,6 +7,17 @@ import (
 	"github.com/hashicorp/go-tfe"
 )
 
+type Writer interface {
+	Output(msg string)
+}
+
+type defaultWriter struct{}
+
+func (d *defaultWriter) Output(msg string) {}
+
+// compile time check
+var _ Writer = (*defaultWriter)(nil)
+
 type Cloud struct {
 	ConfigVersionService
 	RunService
@@ -14,11 +25,11 @@ type Cloud struct {
 	WorkspaceService
 }
 
-func NewCloud(c *tfe.Client) *Cloud {
+func NewCloud(c *tfe.Client, w Writer) *Cloud {
 	return &Cloud{
-		ConfigVersionService: NewConfigVersionService(c),
-		RunService:           NewRunService(c),
-		PlanService:          NewPlanService(c),
-		WorkspaceService:     NewWorkspaceService(c),
+		ConfigVersionService: NewConfigVersionService(c, w),
+		RunService:           NewRunService(c, w),
+		PlanService:          NewPlanService(c, w),
+		WorkspaceService:     NewWorkspaceService(c, w),
 	}
 }

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -9,11 +9,13 @@ import (
 
 type Writer interface {
 	Output(msg string)
+	Error(msg string)
 }
 
 type defaultWriter struct{}
 
 func (d *defaultWriter) Output(msg string) {}
+func (d *defaultWriter) Error(msg string)  {}
 
 // compile time check
 var _ Writer = (*defaultWriter)(nil)

--- a/internal/cloud/configuration_version.go
+++ b/internal/cloud/configuration_version.go
@@ -47,7 +47,7 @@ func (service *configVersionService) UploadConfig(ctx context.Context, options U
 		return configVersion, cvErr
 	}
 
-	service.writer.Output(fmt.Sprintf("Configuration Version has been created: %s\n", configVersion.ID))
+	service.writer.Output(fmt.Sprintf("Configuration Version has been created: %s", configVersion.ID))
 
 	err := service.ConfigurationVersions.Upload(ctx, configVersion.UploadURL, options.ConfigurationDirectory)
 
@@ -64,7 +64,7 @@ func (service *configVersionService) UploadConfig(ctx context.Context, options U
 		if err != nil {
 			return err
 		}
-		service.writer.Output(fmt.Sprintf("Upload Status: '%s'\n", cv.Status))
+		service.writer.Output(fmt.Sprintf("Upload Status: %q", cv.Status))
 		if cv.Status == tfe.ConfigurationUploaded || cv.Status == tfe.ConfigurationErrored {
 			// update configVersion to latest results
 			configVersion = cv

--- a/internal/cloud/configuration_version_test.go
+++ b/internal/cloud/configuration_version_test.go
@@ -17,6 +17,7 @@ import (
 func TestUpload(t *testing.T) {
 	type fields struct {
 		Client *tfe.Client
+		writer Writer
 	}
 
 	type args struct {
@@ -29,6 +30,8 @@ func TestUpload(t *testing.T) {
 		UploadURL: "cv.com",
 		Status:    tfe.ConfigurationUploaded,
 	}
+
+	writer := &defaultWriter{}
 
 	tests := []struct {
 		name        string
@@ -51,6 +54,7 @@ func TestUpload(t *testing.T) {
 			name: "upload success",
 			fields: fields{
 				Client: &tfe.Client{},
+				writer: writer,
 			},
 			args: args{
 				ctx: context.Background(),
@@ -79,6 +83,7 @@ func TestUpload(t *testing.T) {
 			name: "workspace read fails",
 			fields: fields{
 				Client: &tfe.Client{},
+				writer: writer,
 			},
 			args: args{
 				ctx: context.Background(),
@@ -129,6 +134,7 @@ func TestUpload(t *testing.T) {
 
 			client := &configVersionService{
 				Client: tt.fields.Client,
+				writer: writer,
 			}
 			client.Workspaces = mockWs
 			client.ConfigurationVersions = mockCv

--- a/internal/cloud/configuration_version_test.go
+++ b/internal/cloud/configuration_version_test.go
@@ -132,12 +132,13 @@ func TestUpload(t *testing.T) {
 				mockCv.EXPECT().Read(tt.args.ctx, tt.cv.ID).Return(tt.cv, tt.cvCreateErr)
 			}
 
-			client := &configVersionService{
-				Client: tt.fields.Client,
+			m := &cloudMeta{
+				tfe:    tt.fields.Client,
 				writer: writer,
 			}
-			client.Workspaces = mockWs
-			client.ConfigurationVersions = mockCv
+			m.tfe.Workspaces = mockWs
+			m.tfe.ConfigurationVersions = mockCv
+			client := NewConfigVersionService(m)
 
 			got, err := client.UploadConfig(tt.args.ctx, tt.args.options)
 			if (err != nil) != tt.wantErr {

--- a/internal/cloud/plan.go
+++ b/internal/cloud/plan.go
@@ -15,9 +15,7 @@ type PlanService interface {
 }
 
 type planService struct {
-	tfe *tfe.Client
-
-	writer Writer
+	*cloudMeta
 }
 
 func (service *planService) GetPlan(ctx context.Context, planID string) (*tfe.Plan, error) {
@@ -29,6 +27,6 @@ func (service *planService) GetPlan(ctx context.Context, planID string) (*tfe.Pl
 	return data, nil
 }
 
-func NewPlanService(tfe *tfe.Client, w Writer) *planService {
-	return &planService{tfe, w}
+func NewPlanService(meta *cloudMeta) *planService {
+	return &planService{meta}
 }

--- a/internal/cloud/plan.go
+++ b/internal/cloud/plan.go
@@ -16,6 +16,8 @@ type PlanService interface {
 
 type planService struct {
 	tfe *tfe.Client
+
+	writer Writer
 }
 
 func (service *planService) GetPlan(ctx context.Context, planID string) (*tfe.Plan, error) {
@@ -27,6 +29,6 @@ func (service *planService) GetPlan(ctx context.Context, planID string) (*tfe.Pl
 	return data, nil
 }
 
-func NewPlanService(tfe *tfe.Client) *planService {
-	return &planService{tfe}
+func NewPlanService(tfe *tfe.Client, w Writer) *planService {
+	return &planService{tfe, w}
 }

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -95,9 +95,7 @@ type RunService interface {
 }
 
 type runService struct {
-	tfe *tfe.Client
-
-	writer Writer
+	*cloudMeta
 }
 
 func (service *runService) RunLink(ctx context.Context, organization string, run *tfe.Run) (string, error) {
@@ -495,8 +493,8 @@ func outputRunLogLines(logs io.Reader, writer Writer) error {
 	return nil
 }
 
-func NewRunService(tfe *tfe.Client, w Writer) RunService {
-	return &runService{tfe, w}
+func NewRunService(meta *cloudMeta) RunService {
+	return &runService{meta}
 }
 
 func getDesiredRunStatus(run *tfe.Run, policyChecksEnabled bool, costEstimateEnabled bool) []tfe.RunStatus {

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -109,7 +109,7 @@ func (service *runService) RunLink(ctx context.Context, organization string, run
 	}
 	url := service.tfe.BaseURL()
 	link := fmt.Sprintf("%s://%s/app/%s/workspaces/%s/runs/%s", url.Scheme, url.Host, organization, tfWorkspace.Name, run.ID)
-	service.writer.Output(fmt.Sprintf("View Run in Terraform Cloud: %s\n", link))
+	service.writer.Output(fmt.Sprintf("View Run in Terraform Cloud: %s", link))
 
 	return link, nil
 }
@@ -167,7 +167,7 @@ func (service *runService) CreateRun(ctx context.Context, options CreateRunOptio
 		return nil, err
 	}
 
-	service.writer.Output(fmt.Sprintf("Created Run ID: %s\n", run.ID))
+	service.writer.Output(fmt.Sprintf("Created Run ID: %q", run.ID))
 
 	costEstimateEnabled, policyChecksEnabled := hasCostEstimate(run), hasPolicyChecks(run)
 	desiredStatus := getDesiredRunStatus(run, policyChecksEnabled, costEstimateEnabled)
@@ -187,7 +187,7 @@ func (service *runService) CreateRun(ctx context.Context, options CreateRunOptio
 			return err
 		}
 
-		service.writer.Output(fmt.Sprintf("Run Status: '%s'\n", run.Status))
+		service.writer.Output(fmt.Sprintf("Run Status: %q", run.Status))
 
 		done, err := isRunComplete(r, desiredStatus, NoopStatus)
 		if err != nil {
@@ -229,7 +229,7 @@ func (service *runService) ApplyRun(ctx context.Context, options ApplyRunOptions
 			return runErr
 		}
 
-		service.writer.Output(fmt.Sprintf("Run Status: %q\n", run.Status))
+		service.writer.Output(fmt.Sprintf("Run Status: %q", run.Status))
 
 		done, err := isRunComplete(run, []tfe.RunStatus{tfe.RunApplied}, NoopStatus)
 		if err != nil {
@@ -268,7 +268,7 @@ func (service *runService) DiscardRun(ctx context.Context, options DiscardRunOpt
 			return runErr
 		}
 
-		service.writer.Output(fmt.Sprintf("Run Status: %q\n", run.Status))
+		service.writer.Output(fmt.Sprintf("Run Status: %q", run.Status))
 
 		done, err := isRunComplete(run, []tfe.RunStatus{tfe.RunDiscarded}, DiscardNoopStatus)
 		if err != nil {
@@ -316,7 +316,7 @@ func (service *runService) CancelRun(ctx context.Context, options CancelRunOptio
 			return runErr
 		}
 
-		service.writer.Output(fmt.Sprintf("Run Status: %q\n", run.Status))
+		service.writer.Output(fmt.Sprintf("Run Status: %q", run.Status))
 
 		done, err := isRunComplete(run, []tfe.RunStatus{tfe.RunCanceled}, CancelNoopStatus)
 		if err != nil {
@@ -346,7 +346,7 @@ func (service *runService) GetPlanLogs(ctx context.Context, planID string) error
 		return err
 	}
 
-	service.writer.Output(fmt.Sprintf("\n-------------- %s --------------\n", "Plan Log"))
+	service.writer.Output(fmt.Sprintf("-------------- %s --------------", "Plan Log"))
 	err = outputRunLogLines(logReader, service.writer)
 	if err != nil {
 		return err
@@ -366,7 +366,7 @@ func (service *runService) GetApplyLogs(ctx context.Context, applyID string) err
 		return err
 	}
 
-	service.writer.Output(fmt.Sprintf("\n-------------- %s --------------\n", "Apply Log"))
+	service.writer.Output(fmt.Sprintf("-------------- %s --------------", "Apply Log"))
 	err = outputRunLogLines(logReader, service.writer)
 	if err != nil {
 		return err
@@ -405,7 +405,7 @@ func (s *runService) GetPolicyCheckLogs(ctx context.Context, run *tfe.Run) error
 
 		// only log for first sentinel policy
 		if logStart {
-			s.writer.Output(fmt.Sprintf("\n-------------- %s --------------\n", "Sentinel Policy Checks"))
+			s.writer.Output(fmt.Sprintf("-------------- %s --------------", "Sentinel Policy Checks"))
 			logStart = false
 		}
 
@@ -437,22 +437,22 @@ func (s *runService) LogTaskStage(ctx context.Context, run *tfe.Run, stage tfe.S
 	fmt.Println()
 	for _, task := range taskStages.Items {
 		if task.Stage == stage {
-			s.writer.Output(fmt.Sprintf("-------------- %s --------------\n", labelMap[string(stage)]))
-			s.writer.Output(fmt.Sprintf("TaskStage (%s), Status: '%s', Stage: '%s'\n", task.ID, task.Status, task.Stage))
+			s.writer.Output(fmt.Sprintf("-------------- %s --------------", labelMap[string(stage)]))
+			s.writer.Output(fmt.Sprintf("TaskStage (%s), Status: '%s', Stage: '%s'", task.ID, task.Status, task.Stage))
 			for _, taskResult := range task.TaskResults {
 				taskResult, resErr := s.tfe.TaskResults.Read(ctx, taskResult.ID)
 				if resErr != nil {
 					return fmt.Errorf("error reading results for task results: %s", resErr.Error())
 				}
-				s.writer.Output(fmt.Sprintf("- TaskResult (%s), Name: '%s', Status: '%s', EnforcementLevel: '%s', Message: '%s'\n", taskResult.ID, taskResult.TaskName, taskResult.Status, taskResult.WorkspaceTaskEnforcementLevel, taskResult.Message))
+				s.writer.Output(fmt.Sprintf("- TaskResult (%s), Name: '%s', Status: '%s', EnforcementLevel: '%s', Message: '%s'", taskResult.ID, taskResult.TaskName, taskResult.Status, taskResult.WorkspaceTaskEnforcementLevel, taskResult.Message))
 			}
 			evaluations, pErr := s.tfe.PolicyEvaluations.List(ctx, task.ID, &tfe.PolicyEvaluationListOptions{})
 			if pErr != nil {
 				return fmt.Errorf("error reading results for policy evaluations: %s", pErr.Error())
 			}
 			for _, p := range evaluations.Items {
-				s.writer.Output(fmt.Sprintf("- PolicyEvalutation (%s), Status: '%s', PolicyKind: '%s'\n", p.ID, p.Status, p.PolicyKind))
-				s.writer.Output(fmt.Sprintf("  Passed: (%d), AdvisoryFailed: (%d), MandatoryFailed: (%d), Failed: (%d)\n", p.ResultCount.Passed, p.ResultCount.AdvisoryFailed, p.ResultCount.MandatoryFailed, p.ResultCount.Errored))
+				s.writer.Output(fmt.Sprintf("- PolicyEvalutation (%s), Status: '%s', PolicyKind: '%s'", p.ID, p.Status, p.PolicyKind))
+				s.writer.Output(fmt.Sprintf("  Passed: (%d), AdvisoryFailed: (%d), MandatoryFailed: (%d), Failed: (%d)", p.ResultCount.Passed, p.ResultCount.AdvisoryFailed, p.ResultCount.MandatoryFailed, p.ResultCount.Errored))
 			}
 			fmt.Println()
 		}
@@ -465,9 +465,9 @@ func (s *runService) LogCostEstimation(ctx context.Context, run *tfe.Run) {
 		return
 	}
 
-	s.writer.Output(fmt.Sprintf("\n-------------- CostEstimation (%s) --------------\n", run.CostEstimate.ID))
-	s.writer.Output(fmt.Sprintf("Status: '%s', ErrorMessage: '%s'\n", run.CostEstimate.Status, run.CostEstimate.ErrorMessage))
-	s.writer.Output(fmt.Sprintf("PriorMonthlyCost: (%s), ProposedMonthlyCost: (%s), Delta: (%s)\n", run.CostEstimate.PriorMonthlyCost, run.CostEstimate.ProposedMonthlyCost, run.CostEstimate.DeltaMonthlyCost))
+	s.writer.Output(fmt.Sprintf("-------------- CostEstimation (%s) --------------", run.CostEstimate.ID))
+	s.writer.Output(fmt.Sprintf("Status: %q, ErrorMessage: %q", run.CostEstimate.Status, run.CostEstimate.ErrorMessage))
+	s.writer.Output(fmt.Sprintf("PriorMonthlyCost: (%s), ProposedMonthlyCost: (%s), Delta: (%s)", run.CostEstimate.PriorMonthlyCost, run.CostEstimate.ProposedMonthlyCost, run.CostEstimate.DeltaMonthlyCost))
 	fmt.Println()
 }
 

--- a/internal/cloud/run_test.go
+++ b/internal/cloud/run_test.go
@@ -170,7 +170,7 @@ func TestRunService_CreateRun(t *testing.T) {
 			// Verify retry order behavior
 			gomock.InOrder(goMockCalls...)
 
-			client := &runService{
+			m := &cloudMeta{
 				tfe: &tfe.Client{
 					Workspaces:            workspaceMock,
 					ConfigurationVersions: configVersionMock,
@@ -178,6 +178,7 @@ func TestRunService_CreateRun(t *testing.T) {
 				},
 				writer: &defaultWriter{},
 			}
+			client := NewRunService(m)
 
 			_, err := client.CreateRun(tc.ctx, CreateRunOptions{
 				Organization:           tc.orgName,

--- a/internal/cloud/run_test.go
+++ b/internal/cloud/run_test.go
@@ -176,6 +176,7 @@ func TestRunService_CreateRun(t *testing.T) {
 					ConfigurationVersions: configVersionMock,
 					Runs:                  runsMock,
 				},
+				writer: &defaultWriter{},
 			}
 
 			_, err := client.CreateRun(tc.ctx, CreateRunOptions{

--- a/internal/cloud/tfe_client.go
+++ b/internal/cloud/tfe_client.go
@@ -71,5 +71,7 @@ func NewTfeClient(hostFlag string, tokenFlag string, platform string) (*tfe.Clie
 
 	client.RetryServerErrors(true)
 
+	log.Printf("[DEBUG] TFC/E Version: %s", client.RemoteAPIVersion())
+
 	return client, nil
 }

--- a/internal/cloud/workspace.go
+++ b/internal/cloud/workspace.go
@@ -17,9 +17,7 @@ type WorkspaceService interface {
 }
 
 type workspaceService struct {
-	tfe *tfe.Client
-
-	writer Writer
+	*cloudMeta
 }
 
 // wait 5 minutes for current state version finish processing
@@ -77,6 +75,6 @@ func (s *workspaceService) ReadStateOutputs(ctx context.Context, orgName string,
 	return svoList, svoErr
 }
 
-func NewWorkspaceService(tfe *tfe.Client, w Writer) *workspaceService {
-	return &workspaceService{tfe, w}
+func NewWorkspaceService(meta *cloudMeta) *workspaceService {
+	return &workspaceService{meta}
 }

--- a/internal/cloud/workspace.go
+++ b/internal/cloud/workspace.go
@@ -18,6 +18,8 @@ type WorkspaceService interface {
 
 type workspaceService struct {
 	tfe *tfe.Client
+
+	writer Writer
 }
 
 // wait 5 minutes for current state version finish processing
@@ -75,6 +77,6 @@ func (s *workspaceService) ReadStateOutputs(ctx context.Context, orgName string,
 	return svoList, svoErr
 }
 
-func NewWorkspaceService(tfe *tfe.Client) *workspaceService {
-	return &workspaceService{tfe}
+func NewWorkspaceService(tfe *tfe.Client, w Writer) *workspaceService {
+	return &workspaceService{tfe, w}
 }

--- a/internal/cloud/workspace_test.go
+++ b/internal/cloud/workspace_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/go-tfe/mocks"
+	"github.com/hashicorp/tfci/internal/writer"
+	"github.com/mitchellh/cli"
 )
 
 func TestWorkspaceService_ReadStateOutputs(t *testing.T) {
@@ -72,13 +74,15 @@ func TestWorkspaceService_ReadStateOutputs(t *testing.T) {
 				nil,
 			)
 
-			client := &workspaceService{
+			meta := &cloudMeta{
 				tfe: &tfe.Client{
 					Workspaces:          mWorkspace,
 					StateVersions:       mockStateVersion,
 					StateVersionOutputs: mockStateVersionOutputList,
 				},
+				writer: writer.NewWriter(cli.NewMockUi()),
 			}
+			client := NewWorkspaceService(meta)
 
 			result, resultErr := client.ReadStateOutputs(tc.ctx, tc.orgName, tc.workspaceName)
 
@@ -141,13 +145,15 @@ func TestWorkspaceService_ReadStateOutputs_Retry(t *testing.T) {
 			nil,
 		)
 
-		client := &workspaceService{
+		meta := &cloudMeta{
 			tfe: &tfe.Client{
 				Workspaces:          mWorkspace,
 				StateVersions:       mockStateVersion,
 				StateVersionOutputs: mockStateVersionOutputList,
 			},
+			writer: writer.NewWriter(cli.NewMockUi()),
 		}
+		client := NewWorkspaceService(meta)
 
 		// invoke workspace service call
 		client.ReadStateOutputs(ctx, orgName, workspaceName)

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -47,7 +47,7 @@ func (c *Meta) flagSet(name string) *flag.FlagSet {
 	f.Usage = func() {}
 
 	// flag parsed earlier
-	f.BoolVar(&c.json, "json", false, "")
+	f.BoolVar(&c.json, "json", false, "Suppresses all logs and instead returns output value in JSON format")
 
 	return f
 }

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/tfci/internal/cloud"
 	"github.com/hashicorp/tfci/internal/environment"
+	"github.com/mitchellh/cli"
 )
 
 type Status string
@@ -22,11 +23,6 @@ const (
 	Timeout Status = "Timeout"
 	Noop    Status = "Noop"
 )
-
-type Writer interface {
-	Output(msg string)
-	Error(msg string)
-}
 
 type Meta struct {
 	// Organization for Terraform Cloud installation
@@ -39,14 +35,19 @@ type Meta struct {
 	cloud *cloud.Cloud
 	// messages for stdout, platform output
 	messages map[string]*outputMessage
-	// writes to cli.Ui
-	writer Writer
+	// cli ui settings
+	ui cli.Ui
+	// optional flag
+	json bool
 }
 
 func (c *Meta) flagSet(name string) *flag.FlagSet {
 	f := flag.NewFlagSet(name, flag.ContinueOnError)
 	f.SetOutput(ioutil.Discard)
 	f.Usage = func() {}
+
+	// flag parsed earlier
+	f.BoolVar(&c.json, "json", false, "")
 
 	return f
 }
@@ -121,9 +122,9 @@ func WithOrg(org string) func(*Meta) {
 	}
 }
 
-func WithWriter(w Writer) func(*Meta) {
+func WithUi(ui cli.Ui) func(*Meta) {
 	return func(m *Meta) {
-		m.writer = w
+		m.ui = ui
 	}
 }
 

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -43,9 +43,9 @@ type Meta struct {
 	cloud *cloud.Cloud
 	// messages for stdout, platform output
 	messages map[string]*outputMessage
-	//
+	// writer interface to handle result and diagnostic information
 	writer Writer
-	// duplicate flag to prevent flags package error
+	// flag to prevent non-json messages to stdout
 	json bool
 }
 

--- a/internal/command/plan_output.go
+++ b/internal/command/plan_output.go
@@ -29,22 +29,22 @@ func (c *OutputPlanCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
-	plan, pErr := c.cloud.GetPlan(c.Context, c.PlanID)
+	plan, pErr := c.cloud.GetPlan(c.appCtx, c.PlanID)
 	if pErr != nil {
 		c.addOutput("status", string(Error))
 		c.addPlanDetails(plan)
-		c.Ui.Error(fmt.Sprintf("error retrieving plan data %s\n", pErr.Error()))
-		c.Ui.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("error retrieving plan data %s\n", pErr.Error()))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addPlanDetails(plan)
-	c.Ui.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/plan_output.go
+++ b/internal/command/plan_output.go
@@ -25,11 +25,7 @@ func (c *OutputPlanCommand) flags() *flag.FlagSet {
 }
 
 func (c *OutputPlanCommand) Run(args []string) int {
-	flags := c.flags()
-	if err := flags.Parse(args); err != nil {
-		c.addOutput("status", string(Error))
-		c.closeOutput()
-		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+	if err := c.setupCmd(args, c.flags()); err != nil {
 		return 1
 	}
 

--- a/internal/command/plan_output.go
+++ b/internal/command/plan_output.go
@@ -29,7 +29,7 @@ func (c *OutputPlanCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
@@ -37,14 +37,14 @@ func (c *OutputPlanCommand) Run(args []string) int {
 	if pErr != nil {
 		c.addOutput("status", string(Error))
 		c.addPlanDetails(plan)
-		c.ui.Error(fmt.Sprintf("error retrieving plan data %s\n", pErr.Error()))
-		c.ui.Output(c.closeOutput())
+		c.writer.ErrorResult(fmt.Sprintf("error retrieving plan data %s\n", pErr.Error()))
+		c.writer.OutputResult(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addPlanDetails(plan)
-	c.ui.Output(c.closeOutput())
+	c.writer.OutputResult(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/plan_output.go
+++ b/internal/command/plan_output.go
@@ -29,7 +29,7 @@ func (c *OutputPlanCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
@@ -37,14 +37,14 @@ func (c *OutputPlanCommand) Run(args []string) int {
 	if pErr != nil {
 		c.addOutput("status", string(Error))
 		c.addPlanDetails(plan)
-		c.writer.Error(fmt.Sprintf("error retrieving plan data %s\n", pErr.Error()))
-		c.writer.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("error retrieving plan data %s\n", pErr.Error()))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addPlanDetails(plan)
-	c.writer.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/plan_output.go
+++ b/internal/command/plan_output.go
@@ -29,7 +29,7 @@ func (c *OutputPlanCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
@@ -37,14 +37,14 @@ func (c *OutputPlanCommand) Run(args []string) int {
 	if pErr != nil {
 		c.addOutput("status", string(Error))
 		c.addPlanDetails(plan)
-		c.ui.Error(fmt.Sprintf("error retrieving plan data %s\n", pErr.Error()))
-		c.ui.Output(c.closeOutput())
+		c.writer.Error(fmt.Sprintf("error retrieving plan data %s\n", pErr.Error()))
+		c.writer.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addPlanDetails(plan)
-	c.ui.Output(c.closeOutput())
+	c.writer.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/run_apply.go
+++ b/internal/command/run_apply.go
@@ -28,11 +28,7 @@ func (c *ApplyRunCommand) flags() *flag.FlagSet {
 }
 
 func (c *ApplyRunCommand) Run(args []string) int {
-	flags := c.flags()
-	if err := flags.Parse(args); err != nil {
-		c.addOutput("status", string(Error))
-		c.closeOutput()
-		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+	if err := c.setupCmd(args, c.flags()); err != nil {
 		return 1
 	}
 

--- a/internal/command/run_apply.go
+++ b/internal/command/run_apply.go
@@ -32,14 +32,14 @@ func (c *ApplyRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error("applying a run requires a valid run id")
+		c.writer.Error("applying a run requires a valid run id")
 		return 1
 	}
 
@@ -51,7 +51,7 @@ func (c *ApplyRunCommand) Run(args []string) int {
 	if runErr != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
+		c.writer.Error(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
 		return 1
 	}
 
@@ -60,14 +60,14 @@ func (c *ApplyRunCommand) Run(args []string) int {
 		if run.Status == tfe.RunPlannedAndFinished {
 			c.addOutput("status", string(Noop))
 			c.addRunDetails(run)
-			c.ui.Error(fmt.Sprintf("run %s, is planned and finished. There is nothing to do.", c.RunID))
-			c.ui.Output(c.closeOutput())
+			c.writer.Error(fmt.Sprintf("run %s, is planned and finished. There is nothing to do.", c.RunID))
+			c.writer.Output(c.closeOutput())
 			return 0
 		}
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("run %s, cannot be applied", c.RunID))
-		c.ui.Output(c.closeOutput())
+		c.writer.Error(fmt.Sprintf("run %s, cannot be applied", c.RunID))
+		c.writer.Output(c.closeOutput())
 		return 1
 	}
 
@@ -84,14 +84,14 @@ func (c *ApplyRunCommand) Run(args []string) int {
 		status := c.resolveStatus(applyError)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("error applying run, '%s' in Terraform Cloud: %s", c.RunID, applyError.Error()))
-		c.ui.Output(c.closeOutput())
+		c.writer.Error(fmt.Sprintf("error applying run, '%s' in Terraform Cloud: %s", c.RunID, applyError.Error()))
+		c.writer.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.ui.Output(c.closeOutput())
+	c.writer.Output(c.closeOutput())
 	return 0
 }
 
@@ -112,7 +112,7 @@ func (c *ApplyRunCommand) readApplyLogs(run *tfe.Run) {
 	c.cloud.LogTaskStage(c.appCtx, run, tfe.PreApply)
 	// apply logs
 	if logErr := c.cloud.GetApplyLogs(c.appCtx, run.Apply.ID); logErr != nil {
-		c.ui.Error(fmt.Sprintf("failed to read apply logs: %s", logErr.Error()))
+		c.writer.Error(fmt.Sprintf("failed to read apply logs: %s", logErr.Error()))
 	}
 }
 

--- a/internal/command/run_apply.go
+++ b/internal/command/run_apply.go
@@ -32,14 +32,14 @@ func (c *ApplyRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error("applying a run requires a valid run id")
+		c.writer.ErrorResult("applying a run requires a valid run id")
 		return 1
 	}
 
@@ -51,7 +51,7 @@ func (c *ApplyRunCommand) Run(args []string) int {
 	if runErr != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
 		return 1
 	}
 
@@ -60,14 +60,14 @@ func (c *ApplyRunCommand) Run(args []string) int {
 		if run.Status == tfe.RunPlannedAndFinished {
 			c.addOutput("status", string(Noop))
 			c.addRunDetails(run)
-			c.ui.Error(fmt.Sprintf("run %s, is planned and finished. There is nothing to do.", c.RunID))
-			c.ui.Output(c.closeOutput())
+			c.writer.ErrorResult(fmt.Sprintf("run %s, is planned and finished. There is nothing to do.", c.RunID))
+			c.writer.OutputResult(c.closeOutput())
 			return 0
 		}
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("run %s, cannot be applied", c.RunID))
-		c.ui.Output(c.closeOutput())
+		c.writer.ErrorResult(fmt.Sprintf("run %s, cannot be applied", c.RunID))
+		c.writer.OutputResult(c.closeOutput())
 		return 1
 	}
 
@@ -84,14 +84,14 @@ func (c *ApplyRunCommand) Run(args []string) int {
 		status := c.resolveStatus(applyError)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("error applying run, '%s' in Terraform Cloud: %s", c.RunID, applyError.Error()))
-		c.ui.Output(c.closeOutput())
+		c.writer.ErrorResult(fmt.Sprintf("error applying run, '%s' in Terraform Cloud: %s", c.RunID, applyError.Error()))
+		c.writer.OutputResult(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.ui.Output(c.closeOutput())
+	c.writer.OutputResult(c.closeOutput())
 	return 0
 }
 
@@ -112,7 +112,7 @@ func (c *ApplyRunCommand) readApplyLogs(run *tfe.Run) {
 	c.cloud.LogTaskStage(c.appCtx, run, tfe.PreApply)
 	// apply logs
 	if logErr := c.cloud.GetApplyLogs(c.appCtx, run.Apply.ID); logErr != nil {
-		c.ui.Error(fmt.Sprintf("failed to read apply logs: %s", logErr.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("failed to read apply logs: %s", logErr.Error()))
 	}
 }
 

--- a/internal/command/run_apply.go
+++ b/internal/command/run_apply.go
@@ -32,14 +32,14 @@ func (c *ApplyRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error("applying a run requires a valid run id")
+		c.ui.Error("applying a run requires a valid run id")
 		return 1
 	}
 
@@ -51,7 +51,7 @@ func (c *ApplyRunCommand) Run(args []string) int {
 	if runErr != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
+		c.ui.Error(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
 		return 1
 	}
 
@@ -60,14 +60,14 @@ func (c *ApplyRunCommand) Run(args []string) int {
 		if run.Status == tfe.RunPlannedAndFinished {
 			c.addOutput("status", string(Noop))
 			c.addRunDetails(run)
-			c.writer.Error(fmt.Sprintf("run %s, is planned and finished. There is nothing to do.", c.RunID))
-			c.writer.Output(c.closeOutput())
+			c.ui.Error(fmt.Sprintf("run %s, is planned and finished. There is nothing to do.", c.RunID))
+			c.ui.Output(c.closeOutput())
 			return 0
 		}
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.writer.Error(fmt.Sprintf("run %s, cannot be applied", c.RunID))
-		c.writer.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("run %s, cannot be applied", c.RunID))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
@@ -84,14 +84,14 @@ func (c *ApplyRunCommand) Run(args []string) int {
 		status := c.resolveStatus(applyError)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.writer.Error(fmt.Sprintf("error applying run, '%s' in Terraform Cloud: %s", c.RunID, applyError.Error()))
-		c.writer.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("error applying run, '%s' in Terraform Cloud: %s", c.RunID, applyError.Error()))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.writer.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 
@@ -112,7 +112,7 @@ func (c *ApplyRunCommand) readApplyLogs(run *tfe.Run) {
 	c.cloud.LogTaskStage(c.appCtx, run, tfe.PreApply)
 	// apply logs
 	if logErr := c.cloud.GetApplyLogs(c.appCtx, run.Apply.ID); logErr != nil {
-		c.writer.Error(fmt.Sprintf("failed to read apply logs: %s", logErr.Error()))
+		c.ui.Error(fmt.Sprintf("failed to read apply logs: %s", logErr.Error()))
 	}
 }
 

--- a/internal/command/run_cancel.go
+++ b/internal/command/run_cancel.go
@@ -30,11 +30,7 @@ func (c *CancelRunCommand) flags() *flag.FlagSet {
 }
 
 func (c *CancelRunCommand) Run(args []string) int {
-	flags := c.flags()
-	if err := flags.Parse(args); err != nil {
-		c.addOutput("status", string(Error))
-		c.closeOutput()
-		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+	if err := c.setupCmd(args, c.flags()); err != nil {
 		return 1
 	}
 

--- a/internal/command/run_cancel.go
+++ b/internal/command/run_cancel.go
@@ -34,14 +34,14 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error("cancelling a run requires a run id")
+		c.writer.Error("cancelling a run requires a run id")
 		return 1
 	}
 
@@ -51,7 +51,7 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if runErr != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
+		c.writer.Error(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
 		return 1
 	}
 
@@ -59,8 +59,8 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if c.ForceCancel && !run.Actions.IsForceCancelable {
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("run %s, cannot be force-cancelled", c.RunID))
-		c.ui.Output(c.closeOutput())
+		c.writer.Error(fmt.Sprintf("run %s, cannot be force-cancelled", c.RunID))
+		c.writer.Output(c.closeOutput())
 		return 1
 	}
 
@@ -68,8 +68,8 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if !c.ForceCancel && !run.Actions.IsCancelable {
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("run %s, cannot be cancelled", c.RunID))
-		c.ui.Output(c.closeOutput())
+		c.writer.Error(fmt.Sprintf("run %s, cannot be cancelled", c.RunID))
+		c.writer.Output(c.closeOutput())
 		return 1
 	}
 
@@ -86,14 +86,14 @@ func (c *CancelRunCommand) Run(args []string) int {
 		status := c.resolveStatus(cancelErr)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, cancelErr.Error()))
-		c.ui.Output(c.closeOutput())
+		c.writer.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, cancelErr.Error()))
+		c.writer.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.ui.Output(c.closeOutput())
+	c.writer.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/run_cancel.go
+++ b/internal/command/run_cancel.go
@@ -34,14 +34,14 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error("cancelling a run requires a run id")
+		c.writer.ErrorResult("cancelling a run requires a run id")
 		return 1
 	}
 
@@ -51,7 +51,7 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if runErr != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
 		return 1
 	}
 
@@ -59,8 +59,8 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if c.ForceCancel && !run.Actions.IsForceCancelable {
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("run %s, cannot be force-cancelled", c.RunID))
-		c.ui.Output(c.closeOutput())
+		c.writer.ErrorResult(fmt.Sprintf("run %s, cannot be force-cancelled", c.RunID))
+		c.writer.OutputResult(c.closeOutput())
 		return 1
 	}
 
@@ -68,8 +68,8 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if !c.ForceCancel && !run.Actions.IsCancelable {
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("run %s, cannot be cancelled", c.RunID))
-		c.ui.Output(c.closeOutput())
+		c.writer.ErrorResult(fmt.Sprintf("run %s, cannot be cancelled", c.RunID))
+		c.writer.OutputResult(c.closeOutput())
 		return 1
 	}
 
@@ -86,14 +86,14 @@ func (c *CancelRunCommand) Run(args []string) int {
 		status := c.resolveStatus(cancelErr)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, cancelErr.Error()))
-		c.ui.Output(c.closeOutput())
+		c.writer.ErrorResult(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, cancelErr.Error()))
+		c.writer.OutputResult(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.ui.Output(c.closeOutput())
+	c.writer.OutputResult(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/run_cancel.go
+++ b/internal/command/run_cancel.go
@@ -34,24 +34,24 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error("cancelling a run requires a run id")
+		c.ui.Error("cancelling a run requires a run id")
 		return 1
 	}
 
 	// fetch existing run details
-	run, runErr := c.cloud.GetRun(c.Context, cloud.GetRunOptions{RunID: c.RunID})
+	run, runErr := c.cloud.GetRun(c.appCtx, cloud.GetRunOptions{RunID: c.RunID})
 
 	if runErr != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
+		c.ui.Error(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
 		return 1
 	}
 
@@ -59,8 +59,8 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if c.ForceCancel && !run.Actions.IsForceCancelable {
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.Ui.Error(fmt.Sprintf("run %s, cannot be force-cancelled", c.RunID))
-		c.Ui.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("run %s, cannot be force-cancelled", c.RunID))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
@@ -68,12 +68,12 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if !c.ForceCancel && !run.Actions.IsCancelable {
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.Ui.Error(fmt.Sprintf("run %s, cannot be cancelled", c.RunID))
-		c.Ui.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("run %s, cannot be cancelled", c.RunID))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
-	latestRun, cancelErr := c.cloud.CancelRun(c.Context, cloud.CancelRunOptions{
+	latestRun, cancelErr := c.cloud.CancelRun(c.appCtx, cloud.CancelRunOptions{
 		RunID:       c.RunID,
 		Comment:     c.Comment,
 		ForceCancel: c.ForceCancel,
@@ -86,14 +86,14 @@ func (c *CancelRunCommand) Run(args []string) int {
 		status := c.resolveStatus(cancelErr)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.Ui.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, cancelErr.Error()))
-		c.Ui.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, cancelErr.Error()))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.Ui.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 
@@ -101,7 +101,7 @@ func (c *CancelRunCommand) addRunDetails(run *tfe.Run) {
 	if run == nil {
 		return
 	}
-	link, _ := c.cloud.RunLink(c.Context, c.Organization, run)
+	link, _ := c.cloud.RunLink(c.appCtx, c.organization, run)
 	if link != "" {
 		c.addOutput("run_link", link)
 	}

--- a/internal/command/run_cancel.go
+++ b/internal/command/run_cancel.go
@@ -34,14 +34,14 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error("cancelling a run requires a run id")
+		c.ui.Error("cancelling a run requires a run id")
 		return 1
 	}
 
@@ -51,7 +51,7 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if runErr != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
+		c.ui.Error(fmt.Sprintf("unable to read run: %s with: %s", c.RunID, runErr.Error()))
 		return 1
 	}
 
@@ -59,8 +59,8 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if c.ForceCancel && !run.Actions.IsForceCancelable {
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.writer.Error(fmt.Sprintf("run %s, cannot be force-cancelled", c.RunID))
-		c.writer.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("run %s, cannot be force-cancelled", c.RunID))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
@@ -68,8 +68,8 @@ func (c *CancelRunCommand) Run(args []string) int {
 	if !c.ForceCancel && !run.Actions.IsCancelable {
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.writer.Error(fmt.Sprintf("run %s, cannot be cancelled", c.RunID))
-		c.writer.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("run %s, cannot be cancelled", c.RunID))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
@@ -86,14 +86,14 @@ func (c *CancelRunCommand) Run(args []string) int {
 		status := c.resolveStatus(cancelErr)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.writer.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, cancelErr.Error()))
-		c.writer.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, cancelErr.Error()))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.writer.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/run_create.go
+++ b/internal/command/run_create.go
@@ -38,7 +38,7 @@ func (c *CreateRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
@@ -66,14 +66,14 @@ func (c *CreateRunCommand) Run(args []string) int {
 		errMsg := fmt.Sprintf("error while creating run in Terraform Cloud: %s", runError.Error())
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.writer.Error(errMsg)
-		c.writer.Output(c.closeOutput())
+		c.ui.Error(errMsg)
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.writer.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 
@@ -98,7 +98,7 @@ func (c *CreateRunCommand) addRunDetails(run *tfe.Run) {
 		c.addOutput("cost_estimation_id", run.CostEstimate.ID)
 		c.addOutput("cost_estimation_status", string(run.CostEstimate.Status))
 		if run.CostEstimate.ErrorMessage != "" {
-			c.writer.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
+			c.ui.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
 		}
 	}
 
@@ -114,7 +114,7 @@ func (c *CreateRunCommand) readPlanLogs(run *tfe.Run) {
 	c.cloud.LogTaskStage(c.appCtx, run, tfe.PrePlan)
 	// Plan
 	if pLogErr := c.cloud.GetPlanLogs(c.appCtx, run.Plan.ID); pLogErr != nil {
-		c.writer.Error(fmt.Sprintf("failed to read plan logs: %s", pLogErr.Error()))
+		c.ui.Error(fmt.Sprintf("failed to read plan logs: %s", pLogErr.Error()))
 	}
 	// Post Plan task stages
 	c.cloud.LogTaskStage(c.appCtx, run, tfe.PostPlan)
@@ -122,7 +122,7 @@ func (c *CreateRunCommand) readPlanLogs(run *tfe.Run) {
 	c.cloud.LogCostEstimation(c.appCtx, run)
 	// sentinel policies
 	if policyLogErr := c.cloud.GetPolicyCheckLogs(c.appCtx, run); policyLogErr != nil {
-		c.writer.Error(fmt.Sprintf("failed to read policy check logs: %s", policyLogErr.Error()))
+		c.ui.Error(fmt.Sprintf("failed to read policy check logs: %s", policyLogErr.Error()))
 	}
 }
 

--- a/internal/command/run_create.go
+++ b/internal/command/run_create.go
@@ -38,7 +38,7 @@ func (c *CreateRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
@@ -66,14 +66,14 @@ func (c *CreateRunCommand) Run(args []string) int {
 		errMsg := fmt.Sprintf("error while creating run in Terraform Cloud: %s", runError.Error())
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.ui.Error(errMsg)
-		c.ui.Output(c.closeOutput())
+		c.writer.Error(errMsg)
+		c.writer.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.ui.Output(c.closeOutput())
+	c.writer.Output(c.closeOutput())
 	return 0
 }
 
@@ -98,7 +98,7 @@ func (c *CreateRunCommand) addRunDetails(run *tfe.Run) {
 		c.addOutput("cost_estimation_id", run.CostEstimate.ID)
 		c.addOutput("cost_estimation_status", string(run.CostEstimate.Status))
 		if run.CostEstimate.ErrorMessage != "" {
-			c.ui.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
+			c.writer.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
 		}
 	}
 
@@ -114,7 +114,7 @@ func (c *CreateRunCommand) readPlanLogs(run *tfe.Run) {
 	c.cloud.LogTaskStage(c.appCtx, run, tfe.PrePlan)
 	// Plan
 	if pLogErr := c.cloud.GetPlanLogs(c.appCtx, run.Plan.ID); pLogErr != nil {
-		c.ui.Error(fmt.Sprintf("failed to read plan logs: %s", pLogErr.Error()))
+		c.writer.Error(fmt.Sprintf("failed to read plan logs: %s", pLogErr.Error()))
 	}
 	// Post Plan task stages
 	c.cloud.LogTaskStage(c.appCtx, run, tfe.PostPlan)
@@ -122,7 +122,7 @@ func (c *CreateRunCommand) readPlanLogs(run *tfe.Run) {
 	c.cloud.LogCostEstimation(c.appCtx, run)
 	// sentinel policies
 	if policyLogErr := c.cloud.GetPolicyCheckLogs(c.appCtx, run); policyLogErr != nil {
-		c.ui.Error(fmt.Sprintf("failed to read policy check logs: %s", policyLogErr.Error()))
+		c.writer.Error(fmt.Sprintf("failed to read policy check logs: %s", policyLogErr.Error()))
 	}
 }
 

--- a/internal/command/run_create.go
+++ b/internal/command/run_create.go
@@ -34,11 +34,7 @@ func (c *CreateRunCommand) flags() *flag.FlagSet {
 }
 
 func (c *CreateRunCommand) Run(args []string) int {
-	flags := c.flags()
-	if err := flags.Parse(args); err != nil {
-		c.addOutput("status", string(Error))
-		c.closeOutput()
-		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+	if err := c.setupCmd(args, c.flags()); err != nil {
 		return 1
 	}
 

--- a/internal/command/run_create.go
+++ b/internal/command/run_create.go
@@ -38,7 +38,7 @@ func (c *CreateRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
@@ -49,8 +49,8 @@ func (c *CreateRunCommand) Run(args []string) int {
 		c.Message = c.defaultRunMessage()
 	}
 
-	run, runError := c.cloud.CreateRun(c.Context, cloud.CreateRunOptions{
-		Organization:           c.Organization,
+	run, runError := c.cloud.CreateRun(c.appCtx, cloud.CreateRunOptions{
+		Organization:           c.organization,
 		Workspace:              c.Workspace,
 		ConfigurationVersionID: c.ConfigurationVersionID,
 		Message:                c.Message,
@@ -66,14 +66,14 @@ func (c *CreateRunCommand) Run(args []string) int {
 		errMsg := fmt.Sprintf("error while creating run in Terraform Cloud: %s", runError.Error())
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.Ui.Error(errMsg)
-		c.Ui.Output(c.closeOutput())
+		c.ui.Error(errMsg)
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.Ui.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 
@@ -82,7 +82,7 @@ func (c *CreateRunCommand) addRunDetails(run *tfe.Run) {
 		log.Printf("[ERROR] run is not detected")
 		return
 	}
-	runLink, _ := c.cloud.RunService.RunLink(c.Context, c.Organization, run)
+	runLink, _ := c.cloud.RunService.RunLink(c.appCtx, c.organization, run)
 	if runLink != "" {
 		c.addOutput("run_link", runLink)
 	}
@@ -98,7 +98,7 @@ func (c *CreateRunCommand) addRunDetails(run *tfe.Run) {
 		c.addOutput("cost_estimation_id", run.CostEstimate.ID)
 		c.addOutput("cost_estimation_status", string(run.CostEstimate.Status))
 		if run.CostEstimate.ErrorMessage != "" {
-			c.Ui.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
+			c.ui.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
 		}
 	}
 
@@ -111,24 +111,24 @@ func (c *CreateRunCommand) addRunDetails(run *tfe.Run) {
 
 func (c *CreateRunCommand) readPlanLogs(run *tfe.Run) {
 	// Pre Plan task stages
-	c.cloud.LogTaskStage(c.Context, run, tfe.PrePlan)
+	c.cloud.LogTaskStage(c.appCtx, run, tfe.PrePlan)
 	// Plan
-	if pLogErr := c.cloud.GetPlanLogs(c.Context, run.Plan.ID); pLogErr != nil {
-		c.Ui.Error(fmt.Sprintf("failed to read plan logs: %s", pLogErr.Error()))
+	if pLogErr := c.cloud.GetPlanLogs(c.appCtx, run.Plan.ID); pLogErr != nil {
+		c.ui.Error(fmt.Sprintf("failed to read plan logs: %s", pLogErr.Error()))
 	}
 	// Post Plan task stages
-	c.cloud.LogTaskStage(c.Context, run, tfe.PostPlan)
+	c.cloud.LogTaskStage(c.appCtx, run, tfe.PostPlan)
 	// cost estimation
-	c.cloud.LogCostEstimation(c.Context, run)
+	c.cloud.LogCostEstimation(c.appCtx, run)
 	// sentinel policies
-	if policyLogErr := c.cloud.GetPolicyCheckLogs(c.Context, run); policyLogErr != nil {
-		c.Ui.Error(fmt.Sprintf("failed to read policy check logs: %s", policyLogErr.Error()))
+	if policyLogErr := c.cloud.GetPolicyCheckLogs(c.appCtx, run); policyLogErr != nil {
+		c.ui.Error(fmt.Sprintf("failed to read policy check logs: %s", policyLogErr.Error()))
 	}
 }
 
 func (c *CreateRunCommand) defaultRunMessage() string {
-	if c.Env.Context != nil {
-		return fmt.Sprintf("Triggered from Terraform Cloud CI by Author (%s) for SHA (%s)", c.Env.Context.Author(), c.Env.Context.SHAShort())
+	if c.env.Context != nil {
+		return fmt.Sprintf("Triggered from Terraform Cloud CI by Author (%s) for SHA (%s)", c.env.Context.Author(), c.env.Context.SHAShort())
 	}
 	return `Triggered from Terraform Cloud CI`
 }

--- a/internal/command/run_create.go
+++ b/internal/command/run_create.go
@@ -38,7 +38,7 @@ func (c *CreateRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
@@ -66,14 +66,14 @@ func (c *CreateRunCommand) Run(args []string) int {
 		errMsg := fmt.Sprintf("error while creating run in Terraform Cloud: %s", runError.Error())
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.ui.Error(errMsg)
-		c.ui.Output(c.closeOutput())
+		c.writer.ErrorResult(errMsg)
+		c.writer.OutputResult(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.ui.Output(c.closeOutput())
+	c.writer.OutputResult(c.closeOutput())
 	return 0
 }
 
@@ -98,7 +98,7 @@ func (c *CreateRunCommand) addRunDetails(run *tfe.Run) {
 		c.addOutput("cost_estimation_id", run.CostEstimate.ID)
 		c.addOutput("cost_estimation_status", string(run.CostEstimate.Status))
 		if run.CostEstimate.ErrorMessage != "" {
-			c.ui.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
+			c.writer.ErrorResult(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
 		}
 	}
 
@@ -114,7 +114,7 @@ func (c *CreateRunCommand) readPlanLogs(run *tfe.Run) {
 	c.cloud.LogTaskStage(c.appCtx, run, tfe.PrePlan)
 	// Plan
 	if pLogErr := c.cloud.GetPlanLogs(c.appCtx, run.Plan.ID); pLogErr != nil {
-		c.ui.Error(fmt.Sprintf("failed to read plan logs: %s", pLogErr.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("failed to read plan logs: %s", pLogErr.Error()))
 	}
 	// Post Plan task stages
 	c.cloud.LogTaskStage(c.appCtx, run, tfe.PostPlan)
@@ -122,7 +122,7 @@ func (c *CreateRunCommand) readPlanLogs(run *tfe.Run) {
 	c.cloud.LogCostEstimation(c.appCtx, run)
 	// sentinel policies
 	if policyLogErr := c.cloud.GetPolicyCheckLogs(c.appCtx, run); policyLogErr != nil {
-		c.ui.Error(fmt.Sprintf("failed to read policy check logs: %s", policyLogErr.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("failed to read policy check logs: %s", policyLogErr.Error()))
 	}
 }
 

--- a/internal/command/run_discard.go
+++ b/internal/command/run_discard.go
@@ -28,11 +28,7 @@ func (c *DiscardRunCommand) flags() *flag.FlagSet {
 }
 
 func (c *DiscardRunCommand) Run(args []string) int {
-	flags := c.flags()
-	if err := flags.Parse(args); err != nil {
-		c.addOutput("status", string(Error))
-		c.closeOutput()
-		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+	if err := c.setupCmd(args, c.flags()); err != nil {
 		return 1
 	}
 

--- a/internal/command/run_discard.go
+++ b/internal/command/run_discard.go
@@ -32,14 +32,14 @@ func (c *DiscardRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error("discarding a run requires a valid run id")
+		c.ui.Error("discarding a run requires a valid run id")
 		return 1
 	}
 
@@ -50,7 +50,7 @@ func (c *DiscardRunCommand) Run(args []string) int {
 	if runErr != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("unable to read run: %s, with: %s", c.RunID, runErr.Error()))
+		c.ui.Error(fmt.Sprintf("unable to read run: %s, with: %s", c.RunID, runErr.Error()))
 		return 1
 	}
 
@@ -58,8 +58,8 @@ func (c *DiscardRunCommand) Run(args []string) int {
 	if !run.Actions.IsDiscardable {
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.writer.Error(fmt.Sprintf("run: %s cannot be discarded", c.RunID))
-		c.writer.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("run: %s cannot be discarded", c.RunID))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
@@ -76,14 +76,14 @@ func (c *DiscardRunCommand) Run(args []string) int {
 		status := c.resolveStatus(discardErr)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.writer.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, discardErr.Error()))
-		c.writer.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, discardErr.Error()))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.writer.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/run_discard.go
+++ b/internal/command/run_discard.go
@@ -32,14 +32,14 @@ func (c *DiscardRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error("discarding a run requires a valid run id")
+		c.writer.ErrorResult("discarding a run requires a valid run id")
 		return 1
 	}
 
@@ -50,7 +50,7 @@ func (c *DiscardRunCommand) Run(args []string) int {
 	if runErr != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("unable to read run: %s, with: %s", c.RunID, runErr.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("unable to read run: %s, with: %s", c.RunID, runErr.Error()))
 		return 1
 	}
 
@@ -58,8 +58,8 @@ func (c *DiscardRunCommand) Run(args []string) int {
 	if !run.Actions.IsDiscardable {
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("run: %s cannot be discarded", c.RunID))
-		c.ui.Output(c.closeOutput())
+		c.writer.ErrorResult(fmt.Sprintf("run: %s cannot be discarded", c.RunID))
+		c.writer.OutputResult(c.closeOutput())
 		return 1
 	}
 
@@ -76,14 +76,14 @@ func (c *DiscardRunCommand) Run(args []string) int {
 		status := c.resolveStatus(discardErr)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, discardErr.Error()))
-		c.ui.Output(c.closeOutput())
+		c.writer.ErrorResult(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, discardErr.Error()))
+		c.writer.OutputResult(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.ui.Output(c.closeOutput())
+	c.writer.OutputResult(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/run_discard.go
+++ b/internal/command/run_discard.go
@@ -32,25 +32,25 @@ func (c *DiscardRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error("discarding a run requires a valid run id")
+		c.ui.Error("discarding a run requires a valid run id")
 		return 1
 	}
 
 	// fetch latest run details
-	run, runErr := c.cloud.GetRun(c.Context, cloud.GetRunOptions{
+	run, runErr := c.cloud.GetRun(c.appCtx, cloud.GetRunOptions{
 		RunID: c.RunID,
 	})
 	if runErr != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error(fmt.Sprintf("unable to read run: %s, with: %s", c.RunID, runErr.Error()))
+		c.ui.Error(fmt.Sprintf("unable to read run: %s, with: %s", c.RunID, runErr.Error()))
 		return 1
 	}
 
@@ -58,12 +58,12 @@ func (c *DiscardRunCommand) Run(args []string) int {
 	if !run.Actions.IsDiscardable {
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.Ui.Error(fmt.Sprintf("run: %s cannot be discarded", c.RunID))
-		c.Ui.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("run: %s cannot be discarded", c.RunID))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
-	latestRun, discardErr := c.cloud.DiscardRun(c.Context, cloud.DiscardRunOptions{
+	latestRun, discardErr := c.cloud.DiscardRun(c.appCtx, cloud.DiscardRunOptions{
 		RunID:   c.RunID,
 		Comment: c.Comment,
 	})
@@ -76,14 +76,14 @@ func (c *DiscardRunCommand) Run(args []string) int {
 		status := c.resolveStatus(discardErr)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.Ui.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, discardErr.Error()))
-		c.Ui.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, discardErr.Error()))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.Ui.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 
@@ -91,7 +91,7 @@ func (c *DiscardRunCommand) addRunDetails(run *tfe.Run) {
 	if run == nil {
 		return
 	}
-	link, _ := c.cloud.RunLink(c.Context, c.Organization, run)
+	link, _ := c.cloud.RunLink(c.appCtx, c.organization, run)
 	if link != "" {
 		c.addOutput("run_link", link)
 	}

--- a/internal/command/run_discard.go
+++ b/internal/command/run_discard.go
@@ -32,14 +32,14 @@ func (c *DiscardRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error("discarding a run requires a valid run id")
+		c.writer.Error("discarding a run requires a valid run id")
 		return 1
 	}
 
@@ -50,7 +50,7 @@ func (c *DiscardRunCommand) Run(args []string) int {
 	if runErr != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("unable to read run: %s, with: %s", c.RunID, runErr.Error()))
+		c.writer.Error(fmt.Sprintf("unable to read run: %s, with: %s", c.RunID, runErr.Error()))
 		return 1
 	}
 
@@ -58,8 +58,8 @@ func (c *DiscardRunCommand) Run(args []string) int {
 	if !run.Actions.IsDiscardable {
 		c.addOutput("status", string(Error))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("run: %s cannot be discarded", c.RunID))
-		c.ui.Output(c.closeOutput())
+		c.writer.Error(fmt.Sprintf("run: %s cannot be discarded", c.RunID))
+		c.writer.Output(c.closeOutput())
 		return 1
 	}
 
@@ -76,14 +76,14 @@ func (c *DiscardRunCommand) Run(args []string) int {
 		status := c.resolveStatus(discardErr)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, discardErr.Error()))
-		c.ui.Output(c.closeOutput())
+		c.writer.Error(fmt.Sprintf("error discarding run, '%s' in Terraform Cloud: %s", c.RunID, discardErr.Error()))
+		c.writer.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.ui.Output(c.closeOutput())
+	c.writer.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/run_show.go
+++ b/internal/command/run_show.go
@@ -30,14 +30,14 @@ func (c *ShowRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error("showing a run requires a valid run id")
+		c.writer.Error("showing a run requires a valid run id")
 		return 1
 	}
 
@@ -50,14 +50,14 @@ func (c *ShowRunCommand) Run(args []string) int {
 		status := c.resolveStatus(err)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("error showing run, '%s' in Terraform Cloud: %s", c.RunID, err.Error()))
-		c.ui.Output(c.closeOutput())
+		c.writer.Error(fmt.Sprintf("error showing run, '%s' in Terraform Cloud: %s", c.RunID, err.Error()))
+		c.writer.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.ui.Output(c.closeOutput())
+	c.writer.Output(c.closeOutput())
 	return 0
 }
 
@@ -81,7 +81,7 @@ func (c *ShowRunCommand) addRunDetails(run *tfe.Run) {
 		c.addOutput("cost_estimation_id", run.CostEstimate.ID)
 		c.addOutput("cost_estimation_status", string(run.CostEstimate.Status))
 		if run.CostEstimate.ErrorMessage != "" {
-			c.ui.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
+			c.writer.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
 		}
 	}
 

--- a/internal/command/run_show.go
+++ b/internal/command/run_show.go
@@ -30,14 +30,14 @@ func (c *ShowRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error("showing a run requires a valid run id")
+		c.writer.ErrorResult("showing a run requires a valid run id")
 		return 1
 	}
 
@@ -50,14 +50,14 @@ func (c *ShowRunCommand) Run(args []string) int {
 		status := c.resolveStatus(err)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.ui.Error(fmt.Sprintf("error showing run, '%s' in Terraform Cloud: %s", c.RunID, err.Error()))
-		c.ui.Output(c.closeOutput())
+		c.writer.ErrorResult(fmt.Sprintf("error showing run, '%s' in Terraform Cloud: %s", c.RunID, err.Error()))
+		c.writer.OutputResult(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.ui.Output(c.closeOutput())
+	c.writer.OutputResult(c.closeOutput())
 	return 0
 }
 
@@ -81,7 +81,7 @@ func (c *ShowRunCommand) addRunDetails(run *tfe.Run) {
 		c.addOutput("cost_estimation_id", run.CostEstimate.ID)
 		c.addOutput("cost_estimation_status", string(run.CostEstimate.Status))
 		if run.CostEstimate.ErrorMessage != "" {
-			c.ui.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
+			c.writer.ErrorResult(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
 		}
 	}
 

--- a/internal/command/run_show.go
+++ b/internal/command/run_show.go
@@ -26,11 +26,7 @@ func (c *ShowRunCommand) flags() *flag.FlagSet {
 }
 
 func (c *ShowRunCommand) Run(args []string) int {
-	flags := c.flags()
-	if err := flags.Parse(args); err != nil {
-		c.addOutput("status", string(Error))
-		c.closeOutput()
-		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+	if err := c.setupCmd(args, c.flags()); err != nil {
 		return 1
 	}
 

--- a/internal/command/run_show.go
+++ b/internal/command/run_show.go
@@ -30,19 +30,19 @@ func (c *ShowRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error("showing a run requires a valid run id")
+		c.ui.Error("showing a run requires a valid run id")
 		return 1
 	}
 
 	// fetch run
-	run, err := c.cloud.GetRun(c.Context, cloud.GetRunOptions{
+	run, err := c.cloud.GetRun(c.appCtx, cloud.GetRunOptions{
 		RunID: c.RunID,
 	})
 
@@ -50,14 +50,14 @@ func (c *ShowRunCommand) Run(args []string) int {
 		status := c.resolveStatus(err)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.Ui.Error(fmt.Sprintf("error showing run, '%s' in Terraform Cloud: %s", c.RunID, err.Error()))
-		c.Ui.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("error showing run, '%s' in Terraform Cloud: %s", c.RunID, err.Error()))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.Ui.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 
@@ -66,7 +66,7 @@ func (c *ShowRunCommand) addRunDetails(run *tfe.Run) {
 		return
 	}
 
-	runLink, _ := c.cloud.RunLink(c.Context, c.Organization, run)
+	runLink, _ := c.cloud.RunLink(c.appCtx, c.organization, run)
 	if runLink != "" {
 		c.addOutput("run_link", runLink)
 	}
@@ -81,7 +81,7 @@ func (c *ShowRunCommand) addRunDetails(run *tfe.Run) {
 		c.addOutput("cost_estimation_id", run.CostEstimate.ID)
 		c.addOutput("cost_estimation_status", string(run.CostEstimate.Status))
 		if run.CostEstimate.ErrorMessage != "" {
-			c.Ui.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
+			c.ui.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
 		}
 	}
 

--- a/internal/command/run_show.go
+++ b/internal/command/run_show.go
@@ -30,14 +30,14 @@ func (c *ShowRunCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
 	if c.RunID == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error("showing a run requires a valid run id")
+		c.ui.Error("showing a run requires a valid run id")
 		return 1
 	}
 
@@ -50,14 +50,14 @@ func (c *ShowRunCommand) Run(args []string) int {
 		status := c.resolveStatus(err)
 		c.addOutput("status", string(status))
 		c.addRunDetails(run)
-		c.writer.Error(fmt.Sprintf("error showing run, '%s' in Terraform Cloud: %s", c.RunID, err.Error()))
-		c.writer.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("error showing run, '%s' in Terraform Cloud: %s", c.RunID, err.Error()))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addRunDetails(run)
-	c.writer.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 
@@ -81,7 +81,7 @@ func (c *ShowRunCommand) addRunDetails(run *tfe.Run) {
 		c.addOutput("cost_estimation_id", run.CostEstimate.ID)
 		c.addOutput("cost_estimation_status", string(run.CostEstimate.Status))
 		if run.CostEstimate.ErrorMessage != "" {
-			c.writer.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
+			c.ui.Error(fmt.Sprintf("Cost Estimation errored: %s", run.CostEstimate.ErrorMessage))
 		}
 	}
 

--- a/internal/command/upload.go
+++ b/internal/command/upload.go
@@ -36,7 +36,7 @@ func (c *UploadConfigurationCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
@@ -46,15 +46,15 @@ func (c *UploadConfigurationCommand) Run(args []string) int {
 	if dirError != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error(fmt.Sprintf("error resolving directory path %s", dirError.Error()))
+		c.ui.Error(fmt.Sprintf("error resolving directory path %s", dirError.Error()))
 		return 1
 	}
 
 	log.Printf("[DEBUG] target directory for configuration upload: %s", dirPath)
 
-	configVersion, cvError := c.cloud.UploadConfig(c.Context, cloud.UploadOptions{
+	configVersion, cvError := c.cloud.UploadConfig(c.appCtx, cloud.UploadOptions{
 		Workspace:              c.Workspace,
-		Organization:           c.Organization,
+		Organization:           c.organization,
 		ConfigurationDirectory: dirPath,
 		Speculative:            c.Speculative,
 	})
@@ -63,14 +63,14 @@ func (c *UploadConfigurationCommand) Run(args []string) int {
 		status := c.resolveStatus(cvError)
 		c.addOutput("status", string(status))
 		c.addConfigurationDetails(configVersion)
-		c.Ui.Error(fmt.Sprintf("error uploading configuration version to Terraform Cloud: %s", cvError.Error()))
-		c.Ui.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("error uploading configuration version to Terraform Cloud: %s", cvError.Error()))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addConfigurationDetails(configVersion)
-	c.Ui.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/upload.go
+++ b/internal/command/upload.go
@@ -36,7 +36,7 @@ func (c *UploadConfigurationCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
@@ -46,7 +46,7 @@ func (c *UploadConfigurationCommand) Run(args []string) int {
 	if dirError != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error resolving directory path %s", dirError.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("error resolving directory path %s", dirError.Error()))
 		return 1
 	}
 
@@ -63,14 +63,14 @@ func (c *UploadConfigurationCommand) Run(args []string) int {
 		status := c.resolveStatus(cvError)
 		c.addOutput("status", string(status))
 		c.addConfigurationDetails(configVersion)
-		c.ui.Error(fmt.Sprintf("error uploading configuration version to Terraform Cloud: %s", cvError.Error()))
-		c.ui.Output(c.closeOutput())
+		c.writer.ErrorResult(fmt.Sprintf("error uploading configuration version to Terraform Cloud: %s", cvError.Error()))
+		c.writer.OutputResult(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addConfigurationDetails(configVersion)
-	c.ui.Output(c.closeOutput())
+	c.writer.OutputResult(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/upload.go
+++ b/internal/command/upload.go
@@ -32,11 +32,7 @@ func (c *UploadConfigurationCommand) flags() *flag.FlagSet {
 }
 
 func (c *UploadConfigurationCommand) Run(args []string) int {
-	flags := c.flags()
-	if err := flags.Parse(args); err != nil {
-		c.addOutput("status", string(Error))
-		c.closeOutput()
-		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+	if err := c.setupCmd(args, c.flags()); err != nil {
 		return 1
 	}
 

--- a/internal/command/upload.go
+++ b/internal/command/upload.go
@@ -36,7 +36,7 @@ func (c *UploadConfigurationCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
@@ -46,7 +46,7 @@ func (c *UploadConfigurationCommand) Run(args []string) int {
 	if dirError != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error resolving directory path %s", dirError.Error()))
+		c.writer.Error(fmt.Sprintf("error resolving directory path %s", dirError.Error()))
 		return 1
 	}
 
@@ -63,14 +63,14 @@ func (c *UploadConfigurationCommand) Run(args []string) int {
 		status := c.resolveStatus(cvError)
 		c.addOutput("status", string(status))
 		c.addConfigurationDetails(configVersion)
-		c.ui.Error(fmt.Sprintf("error uploading configuration version to Terraform Cloud: %s", cvError.Error()))
-		c.ui.Output(c.closeOutput())
+		c.writer.Error(fmt.Sprintf("error uploading configuration version to Terraform Cloud: %s", cvError.Error()))
+		c.writer.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addConfigurationDetails(configVersion)
-	c.ui.Output(c.closeOutput())
+	c.writer.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/upload.go
+++ b/internal/command/upload.go
@@ -36,7 +36,7 @@ func (c *UploadConfigurationCommand) Run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return 1
 	}
 
@@ -46,7 +46,7 @@ func (c *UploadConfigurationCommand) Run(args []string) int {
 	if dirError != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("error resolving directory path %s", dirError.Error()))
+		c.ui.Error(fmt.Sprintf("error resolving directory path %s", dirError.Error()))
 		return 1
 	}
 
@@ -63,14 +63,14 @@ func (c *UploadConfigurationCommand) Run(args []string) int {
 		status := c.resolveStatus(cvError)
 		c.addOutput("status", string(status))
 		c.addConfigurationDetails(configVersion)
-		c.writer.Error(fmt.Sprintf("error uploading configuration version to Terraform Cloud: %s", cvError.Error()))
-		c.writer.Output(c.closeOutput())
+		c.ui.Error(fmt.Sprintf("error uploading configuration version to Terraform Cloud: %s", cvError.Error()))
+		c.ui.Output(c.closeOutput())
 		return 1
 	}
 
 	c.addOutput("status", string(Success))
 	c.addConfigurationDetails(configVersion)
-	c.writer.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/upload_test.go
+++ b/internal/command/upload_test.go
@@ -24,14 +24,13 @@ func (s *SuccessfulUploader) UploadConfig(_ context.Context, _ cloud.UploadOptio
 
 func meta(cv *tfe.ConfigurationVersion) *Meta {
 	ctx := context.Background()
-	cloudService := &cloud.Cloud{
-		ConfigVersionService: &SuccessfulUploader{
-			configurationVersion: cv,
-		},
+	ui := cli.NewMockUi()
+	writer := writer.NewWriter(ui)
+	cloudService := cloud.NewCloud(&tfe.Client{}, writer)
+	cloudService.ConfigVersionService = &SuccessfulUploader{
+		configurationVersion: cv,
 	}
 	env := &environment.CI{}
-	ui := cli.NewMockUi()
-	writer := writer.NewWriter(ui, false)
 	meta := NewMetaOpts(ctx, cloudService, env, WithWriter(writer))
 	return meta
 }

--- a/internal/command/upload_test.go
+++ b/internal/command/upload_test.go
@@ -34,7 +34,7 @@ func (w *mockWriter) Error(message string) {
 }
 
 func newMockWriter(ui cli.Ui, json bool) *mockWriter {
-	return &mockWriter{&cli.MockUi{}, false}
+	return &mockWriter{ui, false}
 }
 
 func meta(cv *tfe.ConfigurationVersion) *Meta {

--- a/internal/command/upload_test.go
+++ b/internal/command/upload_test.go
@@ -27,8 +27,8 @@ func meta(cv *tfe.ConfigurationVersion) *Meta {
 			configurationVersion: cv,
 		},
 	})
-	meta.Ui = &cli.MockUi{}
-	meta.Env = &environment.CI{}
+	meta.ui = &cli.MockUi{}
+	meta.env = &environment.CI{}
 	return meta
 }
 

--- a/internal/command/upload_test.go
+++ b/internal/command/upload_test.go
@@ -21,32 +21,32 @@ func (s *SuccessfulUploader) UploadConfig(_ context.Context, _ cloud.UploadOptio
 	return s.configurationVersion, nil
 }
 
-type mockWriter struct {
-	ui   cli.Ui
-	json bool
-}
+// type mockWriter struct {
+// 	ui   cli.Ui
+// 	json bool
+// }
 
-func (w *mockWriter) Output(message string) {
-	w.ui.Output(message)
-}
-func (w *mockWriter) Error(message string) {
-	w.ui.Output(message)
-}
+// func (w *mockWriter) Output(message string) {
+// 	w.ui.Output(message)
+// }
+// func (w *mockWriter) Error(message string) {
+// 	w.ui.Output(message)
+// }
 
-func newMockWriter(ui cli.Ui, json bool) *mockWriter {
-	return &mockWriter{ui, false}
-}
+// func newMockWriter(ui cli.Ui, json bool) *mockWriter {
+// 	return &mockWriter{ui, false}
+// }
 
 func meta(cv *tfe.ConfigurationVersion) *Meta {
 	ctx := context.Background()
-	writer := newMockWriter(&cli.MockUi{}, false)
+	ui := &cli.MockUi{}
 	cloudService := &cloud.Cloud{
 		ConfigVersionService: &SuccessfulUploader{
 			configurationVersion: cv,
 		},
 	}
 	env := &environment.CI{}
-	meta := NewMetaOpts(ctx, cloudService, env, WithWriter(writer))
+	meta := NewMetaOpts(ctx, cloudService, env, WithUi(ui))
 	return meta
 }
 

--- a/internal/command/upload_test.go
+++ b/internal/command/upload_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/tfci/internal/cloud"
 	"github.com/hashicorp/tfci/internal/environment"
+	"github.com/hashicorp/tfci/internal/writer"
 	"github.com/mitchellh/cli"
 )
 
@@ -29,7 +30,9 @@ func meta(cv *tfe.ConfigurationVersion) *Meta {
 		},
 	}
 	env := &environment.CI{}
-	meta := NewMetaOpts(ctx, cloudService, env, WithUi(cli.NewMockUi()))
+	ui := cli.NewMockUi()
+	writer := writer.NewWriter(ui, false)
+	meta := NewMetaOpts(ctx, cloudService, env, WithWriter(writer))
 	return meta
 }
 

--- a/internal/command/upload_test.go
+++ b/internal/command/upload_test.go
@@ -21,14 +21,32 @@ func (s *SuccessfulUploader) UploadConfig(_ context.Context, _ cloud.UploadOptio
 	return s.configurationVersion, nil
 }
 
+type mockWriter struct {
+	ui   cli.Ui
+	json bool
+}
+
+func (w *mockWriter) Output(message string) {
+	w.ui.Output(message)
+}
+func (w *mockWriter) Error(message string) {
+	w.ui.Output(message)
+}
+
+func newMockWriter(ui cli.Ui, json bool) *mockWriter {
+	return &mockWriter{&cli.MockUi{}, false}
+}
+
 func meta(cv *tfe.ConfigurationVersion) *Meta {
-	meta := NewMeta(&cloud.Cloud{
+	ctx := context.Background()
+	writer := newMockWriter(&cli.MockUi{}, false)
+	cloudService := &cloud.Cloud{
 		ConfigVersionService: &SuccessfulUploader{
 			configurationVersion: cv,
 		},
-	})
-	meta.ui = &cli.MockUi{}
-	meta.env = &environment.CI{}
+	}
+	env := &environment.CI{}
+	meta := NewMetaOpts(ctx, cloudService, env, WithWriter(writer))
 	return meta
 }
 

--- a/internal/command/upload_test.go
+++ b/internal/command/upload_test.go
@@ -21,32 +21,15 @@ func (s *SuccessfulUploader) UploadConfig(_ context.Context, _ cloud.UploadOptio
 	return s.configurationVersion, nil
 }
 
-// type mockWriter struct {
-// 	ui   cli.Ui
-// 	json bool
-// }
-
-// func (w *mockWriter) Output(message string) {
-// 	w.ui.Output(message)
-// }
-// func (w *mockWriter) Error(message string) {
-// 	w.ui.Output(message)
-// }
-
-// func newMockWriter(ui cli.Ui, json bool) *mockWriter {
-// 	return &mockWriter{ui, false}
-// }
-
 func meta(cv *tfe.ConfigurationVersion) *Meta {
 	ctx := context.Background()
-	ui := &cli.MockUi{}
 	cloudService := &cloud.Cloud{
 		ConfigVersionService: &SuccessfulUploader{
 			configurationVersion: cv,
 		},
 	}
 	env := &environment.CI{}
-	meta := NewMetaOpts(ctx, cloudService, env, WithUi(ui))
+	meta := NewMetaOpts(ctx, cloudService, env, WithUi(cli.NewMockUi()))
 	return meta
 }
 

--- a/internal/command/workspace_output.go
+++ b/internal/command/workspace_output.go
@@ -32,7 +32,7 @@ func (c *WorkspaceOutputCommand) SetupCmd(args []string) (err error) {
 	if err = flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return err
 	}
 	return
@@ -47,7 +47,7 @@ func (c *WorkspaceOutputCommand) Run(args []string) int {
 	if c.Workspace == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.writer.Error("error workspace output list requires a workspace name")
+		c.ui.Error("error workspace output list requires a workspace name")
 		return 1
 	}
 
@@ -56,7 +56,7 @@ func (c *WorkspaceOutputCommand) Run(args []string) int {
 		status := c.resolveStatus(svoErr)
 		c.addOutput("status", string(status))
 		c.closeOutput()
-		c.writer.Error(fmt.Sprintf("error retrieving workspace state version outputs: %s\n", svoErr.Error()))
+		c.ui.Error(fmt.Sprintf("error retrieving workspace state version outputs: %s\n", svoErr.Error()))
 		return 1
 	}
 
@@ -73,7 +73,7 @@ func (c *WorkspaceOutputCommand) Run(args []string) int {
 		multiLine: true,
 	})
 	c.addOutput("status", string(Success))
-	c.writer.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/workspace_output.go
+++ b/internal/command/workspace_output.go
@@ -27,19 +27,8 @@ func (c *WorkspaceOutputCommand) flags() *flag.FlagSet {
 	return f
 }
 
-func (c *WorkspaceOutputCommand) SetupCmd(args []string) (err error) {
-	flags := c.flags()
-	if err = flags.Parse(args); err != nil {
-		c.addOutput("status", string(Error))
-		c.closeOutput()
-		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
-		return err
-	}
-	return
-}
-
 func (c *WorkspaceOutputCommand) Run(args []string) int {
-	if err := c.SetupCmd(args); err != nil {
+	if err := c.setupCmd(args, c.flags()); err != nil {
 		return 1
 	}
 

--- a/internal/command/workspace_output.go
+++ b/internal/command/workspace_output.go
@@ -32,7 +32,7 @@ func (c *WorkspaceOutputCommand) SetupCmd(args []string) (err error) {
 	if err = flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return err
 	}
 	return
@@ -47,7 +47,7 @@ func (c *WorkspaceOutputCommand) Run(args []string) int {
 	if c.Workspace == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error("error workspace output list requires a workspace name")
+		c.writer.Error("error workspace output list requires a workspace name")
 		return 1
 	}
 
@@ -56,7 +56,7 @@ func (c *WorkspaceOutputCommand) Run(args []string) int {
 		status := c.resolveStatus(svoErr)
 		c.addOutput("status", string(status))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error retrieving workspace state version outputs: %s\n", svoErr.Error()))
+		c.writer.Error(fmt.Sprintf("error retrieving workspace state version outputs: %s\n", svoErr.Error()))
 		return 1
 	}
 
@@ -73,7 +73,7 @@ func (c *WorkspaceOutputCommand) Run(args []string) int {
 		multiLine: true,
 	})
 	c.addOutput("status", string(Success))
-	c.ui.Output(c.closeOutput())
+	c.writer.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/workspace_output.go
+++ b/internal/command/workspace_output.go
@@ -32,7 +32,7 @@ func (c *WorkspaceOutputCommand) SetupCmd(args []string) (err error) {
 	if err = flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return err
 	}
 	return
@@ -47,16 +47,16 @@ func (c *WorkspaceOutputCommand) Run(args []string) int {
 	if c.Workspace == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.Ui.Error("error workspace output list requires a workspace name")
+		c.ui.Error("error workspace output list requires a workspace name")
 		return 1
 	}
 
-	svoList, svoErr := c.cloud.ReadStateOutputs(c.Context, c.Organization, c.Workspace)
+	svoList, svoErr := c.cloud.ReadStateOutputs(c.appCtx, c.organization, c.Workspace)
 	if svoErr != nil {
 		status := c.resolveStatus(svoErr)
 		c.addOutput("status", string(status))
 		c.closeOutput()
-		c.Ui.Error(fmt.Sprintf("error retrieving workspace state version outputs: %s\n", svoErr.Error()))
+		c.ui.Error(fmt.Sprintf("error retrieving workspace state version outputs: %s\n", svoErr.Error()))
 		return 1
 	}
 
@@ -73,7 +73,7 @@ func (c *WorkspaceOutputCommand) Run(args []string) int {
 		multiLine: true,
 	})
 	c.addOutput("status", string(Success))
-	c.Ui.Output(c.closeOutput())
+	c.ui.Output(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/workspace_output.go
+++ b/internal/command/workspace_output.go
@@ -32,7 +32,7 @@ func (c *WorkspaceOutputCommand) SetupCmd(args []string) (err error) {
 	if err = flags.Parse(args); err != nil {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("error parsing command-line flags: %s\n", err.Error()))
 		return err
 	}
 	return
@@ -47,7 +47,7 @@ func (c *WorkspaceOutputCommand) Run(args []string) int {
 	if c.Workspace == "" {
 		c.addOutput("status", string(Error))
 		c.closeOutput()
-		c.ui.Error("error workspace output list requires a workspace name")
+		c.writer.ErrorResult("error workspace output list requires a workspace name")
 		return 1
 	}
 
@@ -56,7 +56,7 @@ func (c *WorkspaceOutputCommand) Run(args []string) int {
 		status := c.resolveStatus(svoErr)
 		c.addOutput("status", string(status))
 		c.closeOutput()
-		c.ui.Error(fmt.Sprintf("error retrieving workspace state version outputs: %s\n", svoErr.Error()))
+		c.writer.ErrorResult(fmt.Sprintf("error retrieving workspace state version outputs: %s\n", svoErr.Error()))
 		return 1
 	}
 
@@ -73,7 +73,7 @@ func (c *WorkspaceOutputCommand) Run(args []string) int {
 		multiLine: true,
 	})
 	c.addOutput("status", string(Success))
-	c.ui.Output(c.closeOutput())
+	c.writer.OutputResult(c.closeOutput())
 	return 0
 }
 

--- a/internal/command/workspace_output_test.go
+++ b/internal/command/workspace_output_test.go
@@ -40,7 +40,6 @@ func testWorkspaceOutputCommand(t *testing.T, opts *testWorkspaceOutputCommandOp
 		}
 	}
 	ui := cli.NewMockUi()
-	writer := newMockWriter(ui, false)
 	cloudMockService := &cloud.Cloud{
 		WorkspaceService: &WorkspaceOutputReader{
 			svo: &tfe.StateVersionOutputsList{
@@ -49,7 +48,7 @@ func testWorkspaceOutputCommand(t *testing.T, opts *testWorkspaceOutputCommandOp
 		},
 	}
 
-	meta := NewMetaOpts(context.Background(), cloudMockService, &environment.CI{}, WithWriter(writer))
+	meta := NewMetaOpts(context.Background(), cloudMockService, &environment.CI{}, WithUi(ui))
 
 	return ui, &WorkspaceOutputCommand{Meta: meta}
 }

--- a/internal/command/workspace_output_test.go
+++ b/internal/command/workspace_output_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/tfci/internal/cloud"
 	"github.com/hashicorp/tfci/internal/environment"
+	"github.com/hashicorp/tfci/internal/writer"
 	"github.com/mitchellh/cli"
 )
 
@@ -48,7 +49,8 @@ func testWorkspaceOutputCommand(t *testing.T, opts *testWorkspaceOutputCommandOp
 		},
 	}
 
-	meta := NewMetaOpts(context.Background(), cloudMockService, &environment.CI{}, WithUi(ui))
+	writer := writer.NewWriter(ui, false)
+	meta := NewMetaOpts(context.Background(), cloudMockService, &environment.CI{}, WithWriter(writer))
 
 	return ui, &WorkspaceOutputCommand{Meta: meta}
 }

--- a/internal/command/workspace_output_test.go
+++ b/internal/command/workspace_output_test.go
@@ -39,7 +39,8 @@ func testWorkspaceOutputCommand(t *testing.T, opts *testWorkspaceOutputCommandOp
 			},
 		}
 	}
-	writer := newMockWriter(&cli.MockUi{}, false)
+	ui := cli.NewMockUi()
+	writer := newMockWriter(ui, false)
 	cloudMockService := &cloud.Cloud{
 		WorkspaceService: &WorkspaceOutputReader{
 			svo: &tfe.StateVersionOutputsList{
@@ -47,7 +48,7 @@ func testWorkspaceOutputCommand(t *testing.T, opts *testWorkspaceOutputCommandOp
 			},
 		},
 	}
-	ui := cli.NewMockUi()
+
 	meta := NewMetaOpts(context.Background(), cloudMockService, &environment.CI{}, WithWriter(writer))
 
 	return ui, &WorkspaceOutputCommand{Meta: meta}

--- a/internal/command/workspace_output_test.go
+++ b/internal/command/workspace_output_test.go
@@ -39,7 +39,7 @@ func testWorkspaceOutputCommand(t *testing.T, opts *testWorkspaceOutputCommandOp
 			},
 		}
 	}
-
+	writer := newMockWriter(&cli.MockUi{}, false)
 	cloudMockService := &cloud.Cloud{
 		WorkspaceService: &WorkspaceOutputReader{
 			svo: &tfe.StateVersionOutputsList{
@@ -48,9 +48,7 @@ func testWorkspaceOutputCommand(t *testing.T, opts *testWorkspaceOutputCommandOp
 		},
 	}
 	ui := cli.NewMockUi()
-	meta := NewMeta(cloudMockService)
-	meta.ui = ui
-	meta.env = &environment.CI{}
+	meta := NewMetaOpts(context.Background(), cloudMockService, &environment.CI{}, WithWriter(writer))
 
 	return ui, &WorkspaceOutputCommand{Meta: meta}
 }

--- a/internal/command/workspace_output_test.go
+++ b/internal/command/workspace_output_test.go
@@ -49,8 +49,8 @@ func testWorkspaceOutputCommand(t *testing.T, opts *testWorkspaceOutputCommandOp
 	}
 	ui := cli.NewMockUi()
 	meta := NewMeta(cloudMockService)
-	meta.Ui = ui
-	meta.Env = &environment.CI{}
+	meta.ui = ui
+	meta.env = &environment.CI{}
 
 	return ui, &WorkspaceOutputCommand{Meta: meta}
 }

--- a/internal/command/workspace_output_test.go
+++ b/internal/command/workspace_output_test.go
@@ -40,16 +40,16 @@ func testWorkspaceOutputCommand(t *testing.T, opts *testWorkspaceOutputCommandOp
 			},
 		}
 	}
+
 	ui := cli.NewMockUi()
-	cloudMockService := &cloud.Cloud{
-		WorkspaceService: &WorkspaceOutputReader{
-			svo: &tfe.StateVersionOutputsList{
-				Items: opts.items,
-			},
+	writer := writer.NewWriter(ui)
+	cloudMockService := cloud.NewCloud(&tfe.Client{}, writer)
+	cloudMockService.WorkspaceService = &WorkspaceOutputReader{
+		svo: &tfe.StateVersionOutputsList{
+			Items: opts.items,
 		},
 	}
 
-	writer := writer.NewWriter(ui, false)
 	meta := NewMetaOpts(context.Background(), cloudMockService, &environment.CI{}, WithWriter(writer))
 
 	return ui, &WorkspaceOutputCommand{Meta: meta}

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package writer
 
 import (

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -1,0 +1,37 @@
+package writer
+
+import (
+	"log"
+
+	"github.com/mitchellh/cli"
+)
+
+type Writer struct {
+	json bool
+	ui   cli.Ui
+}
+
+func NewWriter(ui cli.Ui, jsonFlag bool) *Writer {
+	return &Writer{
+		json: jsonFlag,
+		ui:   ui,
+	}
+}
+
+func (w *Writer) Output(message string) {
+	if w.json {
+		log.Printf("[INFO] %s", message)
+		return
+	}
+
+	w.ui.Output(message)
+}
+
+func (w *Writer) Error(message string) {
+	if w.json {
+		log.Printf("[ERROR] %s", message)
+		return
+	}
+
+	w.ui.Error(message)
+}

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -14,15 +14,19 @@ type Writer struct {
 	ui   cli.Ui
 }
 
-func NewWriter(ui cli.Ui, jsonFlag bool) *Writer {
+func NewWriter(ui cli.Ui) *Writer {
 	return &Writer{
-		json: jsonFlag,
-		ui:   ui,
+		ui: ui,
 	}
 }
 
+func (w *Writer) UseJson(json bool) {
+	log.Printf("[DEBUG] Writer using json: %t", json)
+	w.json = json
+}
+
 // In-Progress diagnostic information
-// if *json is set to true, will send log fo to stderr
+// if *json is set to true, will send log formatting to stderr
 func (w *Writer) Output(message string) {
 	if w.json {
 		log.Printf("[INFO] %s", message)

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -21,6 +21,8 @@ func NewWriter(ui cli.Ui, jsonFlag bool) *Writer {
 	}
 }
 
+// In-Progress diagnostic information
+// if *json is set to true, will send log fo to stderr
 func (w *Writer) Output(message string) {
 	if w.json {
 		log.Printf("[INFO] %s", message)
@@ -30,11 +32,25 @@ func (w *Writer) Output(message string) {
 	w.ui.Output(message)
 }
 
+// Diagnostic error information
+// if *json is set to true, will use log formatting to stderr
 func (w *Writer) Error(message string) {
 	if w.json {
 		log.Printf("[ERROR] %s", message)
 		return
 	}
 
+	w.ui.Error(message)
+}
+
+// Final message sent to stdout stream
+// regardless of `json` field we will output the message to stdout stream
+// requires the message string is formatted prior to passing to this method receiver
+func (w *Writer) OutputResult(message string) {
+	w.ui.Output(message)
+}
+
+// Final message sent to stderr stream
+func (w *Writer) ErrorResult(message string) {
 	w.ui.Error(message)
 }

--- a/main.go
+++ b/main.go
@@ -15,14 +15,6 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-type ui struct {
-	cli.Ui
-}
-
-func (u *ui) Warn(msg string) {
-	u.Ui.Output(msg)
-}
-
 var (
 	Ui     cli.Ui
 	appCtx context.Context
@@ -39,11 +31,15 @@ func main() {
 	})
 
 	// Ui settings
-	Ui = &ui{&cli.BasicUi{
-		Writer:      os.Stdout,
-		ErrorWriter: os.Stderr,
-		Reader:      os.Stdin,
-	}}
+	Ui = &cli.ColoredUi{
+		ErrorColor: cli.UiColorRed,
+		WarnColor:  cli.UiColorYellow,
+		Ui: &cli.BasicUi{
+			Writer:      os.Stdout,
+			ErrorWriter: os.Stderr,
+			Reader:      os.Stdin,
+		},
+	}
 
 	appCtx = context.Background()
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Add support for other command line tools such as `jq` by allowing a global `--json` flag argument.

Currently, we are outputting some in-progress/diagnostic information to stdout rather than to stderr. When a `--json` flag is detected regardless of position, we will send all information that is not the final result set to the standard error stream.

A new [writer](https://github.com/hashicorp/tfc-workflows-tooling/blob/0c61894f699825c228be23f6bd74e3dbd4f6cd38/internal/writer/writer.go#L12) package has been added to allow for better dependency injection for other packages.

## Testing plan

1. Execute various commands **without** the use of `--json` flag. No change in behavior and output.
1. Run and verify the following script works as expected, where the apply succeeds.

<details>
  <summary>script.sh</summary>

```bash
# set directory and workspace
DIR=""
WORKSPACE=""

CV_ID=$(go run . upload \
  --workspace=$WORKSPACE \
  --directory=$DIR \
  --json \
  | jq -r '.configuration_version_id'
)

echo $CV_ID

RUN_ID=$(go run . run create \
  --workspace=$WORKSPACE \
  --configuration_version=$CV_ID \
  --json \
  | jq -r '.run_id'
)

RES=$(
  go run . run apply \
  --run=$RUN_ID \
  --json  \
)

echo $RES
```

</details>


## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
