### PR TITLE
fix: workspace output list command option to include with platform output

### DIFF
--- a/.github/actions/test-create-run/action.yml
+++ b/.github/actions/test-create-run/action.yml
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# INTERNAL USE ONLY
+# Refer to https://github.com/hashicorp/tfc-workflows-github for available actions
 name: 'Test Create Run'
 description: "Performs a new plan run in Terraform Cloud, using a configuration version and the workspace’s current variables"
 

--- a/.github/actions/test-upload-configuration/action.yml
+++ b/.github/actions/test-upload-configuration/action.yml
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# INTERNAL USE ONLY
+# Refer to https://github.com/hashicorp/tfc-workflows-github for available actions
 name: "Test Upload Configuration"
 description: "Creates and uploads configuration files for a given workspace"
 

--- a/.github/actions/test-workspace-output/action.yml
+++ b/.github/actions/test-workspace-output/action.yml
@@ -3,8 +3,8 @@
 
 # INTERNAL USE ONLY
 # Refer to https://github.com/hashicorp/tfc-workflows-github for available actions
-name: 'Test Plan Output'
-description: "Returns the plan details for the provided Plan ID"
+name: "Test Workspace Output"
+description: "Returns JSON array of the latest state-version output(s) for a given Terraform Cloud workspace."
 
 inputs:
   # global flags
@@ -20,35 +20,26 @@ inputs:
     required: false
     description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_ORGANIZATION` environment variable"
     default: ""
-  ## required
-  plan:
-    description: "The plan ID to retrieve plan details and JSON execution plan."
+  # required
+  workspace:
     required: true
+    description: "The name of the workspace to create the new configuration version in."
 
 outputs:
   status:
     description: "The result of the operation. Possible values are `Success`, `Error` or `Timeout`"
-  add:
-    description: "Resource Additions from the Terraform Cloud plan."
-  change:
-    description: "Resource Changes from the Terraform Cloud plan."
-  destroy:
-    description: "Resource Destructions from the Terraform Cloud plan."
-  plan_id:
-    description: "The provided plan ID."
-  plan_status:
-    description: "The status of the Plan."
+  outputs:
+    description: "JSON array containing the workspace outputs. Sensitive values are redacted."
 
 runs:
   using: docker
   image: ../../../Dockerfile
   args:
-  - tfci
-  ## global flags
-  - -hostname=${{ inputs.hostname }}
-  - -token=${{ inputs.token }}
-  - -organization=${{ inputs.organization }}
-  ## command
-  - plan
-  - output
-  - -plan=${{ inputs.plan }}
+    - tfci
+    ## global flags
+    - -hostname=${{ inputs.hostname }}
+    - -token=${{ inputs.token }}
+    - -organization=${{ inputs.organization }}
+    ## command arguments
+    - workspace ouput list
+    - -workspace=${{ inputs.workspace }}

--- a/internal/command/workspace_output.go
+++ b/internal/command/workspace_output.go
@@ -69,8 +69,9 @@ func (c *WorkspaceOutputCommand) Run(args []string) int {
 	}
 
 	c.addOutputWithOpts("outputs", workspaceOutputs, &outputOpts{
-		stdOut:    true,
-		multiLine: true,
+		stdOut:      true,
+		multiLine:   true,
+		platformOut: true,
 	})
 	c.addOutput("status", string(Success))
 	c.Ui.Output(c.closeOutput())


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

`outputs` json array is currently being omitted from being sent to github/gitlab output mistakenly. Due to zero value of boolean being false (Not to be confused w/ stdout)

Will need to cut another release before rolling out to github & gitlab repositories.

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
