### PR TITLE
fix: broken test mock service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 
 ## Enhancements
+* Add support for saved plans by @1newsr [#57](https://github.com/hashicorp/tfc-workflows-tooling/pull/57)
 
 ## Bug Fixes
 
@@ -16,8 +17,6 @@
 
 ## Enhancements
 * Adds new command, `workspace output list` to retrieve outputs for an existing Terraform Cloud workspace by @mjyocca [#29](https://github.com/hashicorp/tfc-workflows-tooling/pull/29)
-
-* Add support for saved plans by @1newsr [#57](https://github.com/hashicorp/tfc-workflows-tooling/pull/57)
 
 ## Bug Fixes
 * Fixes issue with `payload` output missing from `run create`, `run show`, `upload`, `plan output` commands by @mjyocca [#46](https://github.com/hashicorp/tfc-workflows-tooling/pull/46)

--- a/internal/cloud/run_test.go
+++ b/internal/cloud/run_test.go
@@ -43,6 +43,7 @@ func testGenerateServiceMocks(t *testing.T, ctrl *gomock.Controller, tc createRu
 		ConfigurationVersion: tc.tfeConfigVersion,
 		Workspace:            tc.tfeWorkspace,
 		PlanOnly:             tfe.Bool(tc.tfeRun.PlanOnly),
+		SavePlan:             tfe.Bool(tc.tfeRun.SavePlan),
 		Message:              tfe.String(""),
 		Variables:            []*tfe.RunVariable{},
 	}).Return(tc.tfeRun, nil)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

* Moves changelog entry to unreleased enhanced section
* Fixes runs mock service to represent new saved plan option

