### PR TITLE
fix: e2e workflow matrix strategy

### DIFF
--- a/.github/workflows/e2e.workflow.yml
+++ b/.github/workflows/e2e.workflow.yml
@@ -41,7 +41,7 @@ jobs:
     needs: initialize-tfc-resources
     strategy:
       matrix:
-        option:
+        include:
           - speculative: true
             save_plan: false
           - speculative: false
@@ -58,16 +58,16 @@ jobs:
         with:
           workspace: ci-workspace-test
           directory: .github/terraform/workspace
-          speculative: ${{ matrix.option.speculative }}
-          provisional: ${{ matrix.option.save_plan }}
+          speculative: ${{ matrix.speculative }}
+          provisional: ${{ matrix.save_plan }}
 
       - uses: ./.github/actions/test-create-run
         id: create-run
         with:
           configuration_version: ${{ steps.upload.outputs.configuration_version_id }}
           workspace: ci-workspace-test
-          plan_only: ${{ matrix.option.speculative }}
-          save_plan: ${{ matrix.option.save_plan }}
+          plan_only: ${{ matrix.speculative }}
+          save_plan: ${{ matrix.save_plan }}
 
       - uses: ./.github/actions/test-plan-output
         id: plan


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Previous matrix strategy resulted in null/blank option for save_plan with create-run action

## External links

- [GitHub Actions Matrix Docs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-adding-configurations)
- [Failed scheduled job](https://github.com/hashicorp/tfc-workflows-tooling/actions/runs/6887178566)

