### PR TITLE
Adding Adds support for Terraform destroy under  command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Enhancements
 * Add support for saved plans by @1newsr [#57](https://github.com/hashicorp/tfc-workflows-tooling/pull/57)
 
-# v1.1.2
+# v1.2.0
 
 ## Enhancements
 * Adds support for Terraform destroy under `run create` command by @trutled3 [#80](https://github.com/hashicorp/tfc-workflows-tooling/pull/80)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,7 @@
 
 ## Enhancements
 * Add support for saved plans by @1newsr [#57](https://github.com/hashicorp/tfc-workflows-tooling/pull/57)
-
-# v1.2.0
-
-## Enhancements
 * Adds support for Terraform destroy under `run create` command by @trutled3 [#80](https://github.com/hashicorp/tfc-workflows-tooling/pull/80)
-
-## Bug Fixes
 
 # v1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 # v1.1.2
 
 ## Enhancements
-* Adds support for Terraform destroy under `run create` command by @trutled3 [#](https://github.com/hashicorp/tfc-workflows-tooling/pull/)
+* Adds support for Terraform destroy under `run create` command by @trutled3 [#80](https://github.com/hashicorp/tfc-workflows-tooling/pull/80)
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Add support for saved plans by @1newsr [#57](https://github.com/hashicorp/tfc-workflows-tooling/pull/57)
 * Adds support for Terraform destroy under `run create` command by @trutled3 [#80](https://github.com/hashicorp/tfc-workflows-tooling/pull/80)
 
+## Bug Fixes
+
 # v1.1.1
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Enhancements
 * Add support for saved plans by @1newsr [#57](https://github.com/hashicorp/tfc-workflows-tooling/pull/57)
 
+# v1.1.2
+
+## Enhancements
+* Adds support for Terraform destroy under `run create` command by @trutled3 [#](https://github.com/hashicorp/tfc-workflows-tooling/pull/)
+
 ## Bug Fixes
 
 # v1.1.1

--- a/docs/ADOPTION.md
+++ b/docs/ADOPTION.md
@@ -38,6 +38,7 @@ View the GitLab [Base-Template](https://github.com/hashicorp/tfc-workflows-gitla
 |------------|-------------------------------------|------------------------------------------------|
 | Plan       |  `terraform plan`                   |  commands: `upload`, `run create`              |
 | Apply      |  `terraform apply -auto-approve`    |  commands: `upload`,  `run create`, `run apply`|
+| Destroy    |  `terraform plan -destroy -out=destroy.tfplan` , `terraform apply destroy.tfplan`| commands: `run create -is-destroy=true` |
 
 #### Terraform Plan
 
@@ -53,6 +54,15 @@ Terraform Cloud CLI can execute an apply run with, `terraform apply` that will a
 
 With Tfci and Terraform Cloud API driven runs:
 - Upload terraform configuration as a ConfigurationVersion
+- New plan run executes
+- If plan phase was successful, an apply can be confirmed to proceed
+
+#### Terraform Destroy
+
+Terraform Cloud CLI can execute a destroy run with, `terraform plan -destroy -out=destroy.tfplan` followed by `terraform apply destroy.tfplan`, that will also upload the configuration and start a new Terraform Cloud run that will plan and destroy.
+
+With Tfci and Terraform Cloud API driven runs:
+- Upload terraform configuraiton as a ConfigurationVersion
 - New plan run executes
 - If plan phase was successful, an apply can be confirmed to proceed
 

--- a/docs/ADOPTION.md
+++ b/docs/ADOPTION.md
@@ -62,7 +62,7 @@ With Tfci and Terraform Cloud API driven runs:
 Terraform Cloud CLI can execute a destroy run with, `terraform plan -destroy -out=destroy.tfplan` followed by `terraform apply destroy.tfplan`, that will also upload the configuration and start a new Terraform Cloud run that will plan and destroy.
 
 With Tfci and Terraform Cloud API driven runs:
-- Upload terraform configuraiton as a ConfigurationVersion
+- Upload terraform configuration as a ConfigurationVersion
 - New plan run executes
 - If plan phase was successful, an apply can be confirmed to proceed
 

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -58,6 +58,7 @@ type CreateRunOptions struct {
 	ConfigurationVersionID string
 	Message                string
 	PlanOnly               bool
+	IsDestroy              bool
 	SavePlan               bool
 	RunVariables           []*tfe.RunVariable
 }
@@ -157,6 +158,7 @@ func (service *runService) CreateRun(ctx context.Context, options CreateRunOptio
 	createOpts.Workspace = w
 	createOpts.Message = &options.Message
 	createOpts.PlanOnly = tfe.Bool(options.PlanOnly)
+	createOpts.IsDestroy = tfe.Bool(options.IsDestroy)
 	createOpts.SavePlan = tfe.Bool(options.SavePlan)
 	createOpts.Variables = options.RunVariables
 
@@ -507,7 +509,7 @@ func getDesiredRunStatus(run *tfe.Run, policyChecksEnabled bool, costEstimateEna
 		tfe.RunPlannedAndFinished,
 		tfe.RunApplied,
 	}
-	
+
 	if run.SavePlan {
 		desiredStatus = append(desiredStatus, tfe.RunPlannedAndSaved)
 	}

--- a/internal/cloud/run_test.go
+++ b/internal/cloud/run_test.go
@@ -43,6 +43,7 @@ func testGenerateServiceMocks(t *testing.T, ctrl *gomock.Controller, tc createRu
 		ConfigurationVersion: tc.tfeConfigVersion,
 		Workspace:            tc.tfeWorkspace,
 		PlanOnly:             tfe.Bool(tc.tfeRun.PlanOnly),
+		IsDestroy:            tfe.Bool(tc.tfeRun.IsDestroy),
 		SavePlan:             tfe.Bool(tc.tfeRun.SavePlan),
 		Message:              tfe.String(""),
 		Variables:            []*tfe.RunVariable{},
@@ -66,6 +67,28 @@ func TestRunService_CreateRun(t *testing.T) {
 			tfeRun: &tfe.Run{
 				ID:       "run-***",
 				PlanOnly: true,
+			},
+			statusChanges: []tfe.RunStatus{
+				tfe.RunPlanning,
+				tfe.RunPlanning,
+				tfe.RunCostEstimated,
+				tfe.RunPolicyChecked,
+			},
+			finalStatus: tfe.RunPlannedAndFinished,
+		},
+		{
+			name:          "destroy-run",
+			orgName:       "test",
+			workspaceName: "my-workspace",
+			ctx:           context.Background(),
+			tfeWorkspace:  &tfe.Workspace{ID: "ws-***"},
+			tfeConfigVersion: &tfe.ConfigurationVersion{
+				ID:     "cv-***",
+				Status: tfe.ConfigurationUploaded,
+			},
+			tfeRun: &tfe.Run{
+				ID:        "run-***",
+				IsDestroy: true,
 			},
 			statusChanges: []tfe.RunStatus{
 				tfe.RunPlanning,
@@ -187,6 +210,7 @@ func TestRunService_CreateRun(t *testing.T) {
 				Workspace:              tc.workspaceName,
 				Message:                "",
 				PlanOnly:               tc.tfeRun.PlanOnly,
+				IsDestroy:              tc.tfeRun.IsDestroy,
 				RunVariables:           []*tfe.RunVariable{},
 			})
 

--- a/internal/command/run_create.go
+++ b/internal/command/run_create.go
@@ -20,8 +20,9 @@ type CreateRunCommand struct {
 	ConfigurationVersionID string
 	Message                string
 
-	PlanOnly bool
-	SavePlan bool
+	PlanOnly  bool
+	IsDestroy bool
+	SavePlan  bool
 }
 
 func (c *CreateRunCommand) flags() *flag.FlagSet {
@@ -30,6 +31,7 @@ func (c *CreateRunCommand) flags() *flag.FlagSet {
 	f.StringVar(&c.ConfigurationVersionID, "configuration_version", "", "The Configuration Version ID to use for this run.")
 	f.StringVar(&c.Message, "message", "", "Specifies the message to be associated with this run. A default message will be set.")
 	f.BoolVar(&c.PlanOnly, "plan-only", false, "Specifies if this is a Terraform Cloud speculative, plan-only run that cannot be applied.")
+	f.BoolVar(&c.IsDestroy, "is-destroy", false, "Specifies that the plan is a destroy plan. When true, the plan destroys all provisioned resources.")
 	f.BoolVar(&c.SavePlan, "save-plan", false, "Specifies whether to create a saved plan. Saved-plan runs perform their plan and checks immediately, but won't lock the workspace and become its current run until they are confirmed for apply.")
 	return f
 }
@@ -52,6 +54,7 @@ func (c *CreateRunCommand) Run(args []string) int {
 		ConfigurationVersionID: c.ConfigurationVersionID,
 		Message:                c.Message,
 		PlanOnly:               c.PlanOnly,
+		IsDestroy:              c.IsDestroy,
 		SavePlan:               c.SavePlan,
 		RunVariables:           runVars,
 	})


### PR DESCRIPTION
## Description

This pull request adds the capability to create a destroy run by setting the `data.attributes.is-destroy` key.

<br class="Apple-interchange-newline">

## Testing plan

1.  Build tfci, `go build`
2. `export TF_API_TOKEN=<TOKEN>`
3. `export TF_CLOUD_ORGANIZATION=<ORG>`
4. Run tfci, `tfci -hostname=terraform.duke-energy.com -organization=rdpautomation-test run create -workspace=airflow-sbx -is-destroy=true

## External links

- [API documentation](https://developer.hashicorp.com/terraform/enterprise/api-docs/run#request-body)
- [tfe GO package, RunCreateOptions](https://pkg.go.dev/github.com/hashicorp/go-tfe#RunCreateOptions)