### PR TITLE
Add tfci binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore binary
+tfci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## Bug Fixes
 
+## Additional changes
+* Adds the tfci binary to .gitignore [#81](https://github.com/hashicorp/tfc-workflows-tooling/pull/81)
+
 # v1.1.1
 
 ## Enhancements


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR adds the tfci binary to .gitignore to ensure that it is not accidentally included in any future PRs

## Testing plan
1. Run "go build" from the root directory of this repo
2. Observe that the generated tfci binary is not tracked by git.

