### PR TITLE
docs: add sections for github and gitlab

### DIFF
--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -15,8 +15,8 @@ For each meaningful change, check the following:
 
 Prepare the changelog for a new release:
 
-1. Replace # Unreleased with the version you are missing.
-1. Ensure to add a new # Unreleased section at the top of the changelog for future changes. This will make it clearer to authors where to add their changelog entry.
+1. Replace `# Unreleased` with the version you are missing.
+1. Ensure to add a new `# Unreleased section` at the top of the changelog for future changes. This will make it clearer to authors where to add their changelog entry.
 1. Ensure each existing changelog entry for the new release has the author(s) attributed and a pull request linked. i.e `- Some new feature/bugfix by @some-github-user (#3)[link-to-pull-request]`
 1. Open a pull request with these changes with a title similar to `vX.XX.XX Changelog`. Once approved and merged, you can go ahead and create the release.
 
@@ -47,3 +47,94 @@ Markdown Examples:
 
 6. Click “Publish release” to save and publish your release.
 7. Monitor the [Build and Release GitHub Workflow](/.github/workflows/build-release.workflow.yml) and verify it has succeeded before proceeding with any downstream dependent releases.
+
+
+### GitHub Actions Release Process: [hashicorp/tfc-workflows-github](https://github.com/hashicorp/tfc-workflows-github)
+
+#### Preparing a release
+
+Find the latest release tag and compare with the main branch to fully understand the changes to be released. You can compare the last release tag with main with the following example for [GitHub](https://github.com/hashicorp/tfc-workflows-github/compare/v1.1.1...main).
+
+For each meaningful change, check the following:
+1. Each change, except for documentation, is added to CHANGELOG.md.
+2. If there are new features and enhancements in the form of either new commands or new command options, the relevant */action.yml files are updated to reflect the changes.
+  * Before preparing a release, create a separate PR including the changes for new actions or updates to existing actions if the main branch . Use a separate project to test the requested changes using your branch as the action version. i.e upload-configuration@some-user/test-branch.
+
+Prepare the changelog for a new release:
+1. Replace `# Unreleased` with the version you are missing.
+2. Ensure to add a new `# Unreleased` section at the top of the changelog for future changes. This will make it clearer to authors where to add their changelog entry.
+3. Ensure each existing changelog entry for the new release has the author(s) attributed and a pull request linked. i.e `- Some new feature/bugfix by @some-github-user (#3)[link-to-pull-request]`
+4. Open a pull request with these changes with a title similar to `vX.XX.XX Changelog`. Once approved and merged, you can go ahead and create the release.
+
+#### Creating a release
+
+1. [Create a new release in GitHub](https://help.github.com/en/github/administering-a-repository/creating-releases) by clicking “Releases“ and “Draft a new release”
+2. Set the Tag Version to a new tag, preferably using the same tag version as [TFCI]( ) to keep the projects consistent.  [More on Semantic Versioning](https://semver.org/).
+3. Set the `Target` as `main`.
+4. Set the `Release Title` to the tag you created, `vX.X.X`
+5. Use the description section to describe the changes. Make sure to include the changelog entries for this release with the author(s) attributed and pull request linked.
+
+Use the following headers in the description of your release:
+* `Breaking Changes`: Use this for any changes that aren't backwards compatible. Include details on how tot handle these changes.
+* `Features`: Use this for any large new features that are added.
+* `Enhancements`: Use this for smaller new features that are added.
+* `Bug Fixes`: Use this for nay bugs that were fixed.
+* `Notes`: Use this for additional notes regarding upcoming deprecations, or other information to highlight.
+
+Markdown Examples:
+
+```
+## Enhancements
+* Add description of new small feature by @some-github-user (#7)[link-to-pull-request]
+
+## Bug Fixes
+* Fix description for a bug by @some-github-user (#7)[link-to-pull-request]
+```
+
+6. Click “Publish release” to save and publish your release.
+
+
+### GitLab Pipelines Release Process: [hashicorp/tfc-workflows-gitlab](https://github.com/hashicorp/tfc-workflows-gitlab)
+
+#### Preparing a release
+
+Find the latest release tag and compare with the main branch to fully understand the changes to be released. You can compare the last release tag with main with the following [example](`https://github.com/hashicorp/tfc-workflows-github/compare/v1.1.1...main `).
+
+For each meaningful change, check the following:
+1. Each change, except for documentation, is added to CHANGELOG.md.
+2. If there are new features and enhancements in the form of either new commands or new command options, the relevant yml workflow files are updated to reflect the changes.
+  * Before preparing a release, create a separate PR including the changes for new actions or updates to existing actions if the main branch . Use a separate project to test the requested changes using your branch as the action version. i.e upload-configuration@some-user/test-branch.
+
+Prepare the changelog for a new release:
+
+1. Replace `# Unreleased `with the version you are missing.
+2. Ensure to add a new `# Unreleased` section at the top of the changelog for future changes. This will make it clearer to authors where to add their changelog entry.
+3. Ensure each existing changelog entry for the new release has the author(s) attributed and a pull request linked. i.e `- Some new feature/bugfix by @some-github-user (#3)[link-to-pull-request]`
+4. Open a pull request with these changes with a title similar to `vX.XX.XX Changelog`. Once approved and merged, you can go ahead and create the release.
+
+#### Creating a release
+
+1. [Create a new release in GitHub](https://help.github.com/en/github/administering-a-repository/creating-releases) by clicking “Releases“ and “Draft a new release”
+2. Set the `Tag Version` to a new tag, preferably using the same tag version as [TFCI]( ) to keep the projects consistent.  [More on Semantic Versioning](https://semver.org/).
+3. Set the `Target` as `main`.
+4. Set the `Release Title` to the tag you created, `vX.X.X`
+5. Use the description section to describe the changes. Make sure to include the changelog entries for this release with the author(s) attributed and pull request linked.
+
+Use the following headers in the description of your release:
+* `Breaking Changes`: Use this for any changes that aren't backwards compatible. Include details on how tot handle these changes.
+* `Features`: Use this for any large new features that are added.
+* `Enhancements`: Use this for smaller new features that are added.
+* `Bug Fixes`: Use this for nay bugs that were fixed.
+* `Notes`: Use this for additional notes regarding upcoming deprecations, or other information to highlight.
+
+Markdown Examples:
+
+```
+## Enhancements
+* Add description of new small feature by @some-github-user (#7)[link-to-pull-request]
+
+## Bug Fixes
+* Fix description for a bug by @some-github-user (#7)[link-to-pull-request]
+```
+
+6. Click “Publish release” to save and publish your release.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -53,7 +53,7 @@ Markdown Examples:
 
 #### Preparing a release
 
-Find the latest release tag and compare with the main branch to fully understand the changes to be released. You can compare the last release tag with main with the following example for [GitHub](https://github.com/hashicorp/tfc-workflows-github/compare/v1.1.1...main).
+Find the latest release tag and compare with the main branch to fully understand the changes to be released. You can compare the last release tag with main with the following example for [tfc-workflows-github](https://github.com/hashicorp/tfc-workflows-github/compare/v1.1.1...main).
 
 For each meaningful change, check the following:
 1. Each change, except for documentation, is added to CHANGELOG.md.
@@ -98,7 +98,7 @@ Markdown Examples:
 
 #### Preparing a release
 
-Find the latest release tag and compare with the main branch to fully understand the changes to be released. You can compare the last release tag with main with the following [example](`https://github.com/hashicorp/tfc-workflows-github/compare/v1.1.1...main `).
+Find the latest release tag and compare with the main branch to fully understand the changes to be released. You can compare the last release tag with main with the following example for [tfc-workflows-gitlab](`https://github.com/hashicorp/tfc-workflows-gitlab/compare/v1.1.1...main `).
 
 For each meaningful change, check the following:
 1. Each change, except for documentation, is added to CHANGELOG.md.


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.

If your changes includes important functionality or bug fixes, please add an entry in the CHANGELOG.md file in the `# Unreleased` section. Or open a follow-up PR to update the CHANGELOG.md with a note on your changes.
-->

## Description

Adds sections for GitHub and GitLab for the release process
