### PR TITLE
fix: omit empty target argument

### DIFF
--- a/internal/command/run_create.go
+++ b/internal/command/run_create.go
@@ -37,6 +37,10 @@ func (v *flagStringSlice) String() string {
 	return strings.Join(*v, ",")
 }
 func (v *flagStringSlice) Set(raw string) error {
+	// omit if `--target=` or `--target=""`
+	if raw == "" {
+		return nil
+	}
 	targetSegments := strings.Split(raw, ",")
 	*v = append(*v, targetSegments...)
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.

If your changes includes important functionality or bug fixes, please add an entry in the CHANGELOG.md file in the `# Unreleased` section. Or open a follow-up PR to update the CHANGELOG.md with a note on your changes.
-->

## Description

Fixes case where a user may pass a `--target=` or `--target=""` argument.

Prior, if an argument was empty we would allocate a slice with an empty string, causing go-tfe sdk to include TargetAddrs with the request, resulting in a failed run.

## Testing plan

1. Create a run with --target= or --target=""
2. With fix, verify run completes successfully

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
