### PR TITLE
Avoids cross compilation in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Notes
 * Updates documentation and references from "Terraform Cloud" to "HCP Terraform" by @mjyocca [#107](https://github.com/hashicorp/tfc-workflows-tooling/pull/107)
+* Compiles for Linux regardless of current CPU architecture when using the provided Dockerfile by @ggambetti [#113](https://github.com/hashicorp/tfc-workflows-tooling/pull/113)
 
 # v1.3.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ ARG VERSION
 
 ENV GO111MODULE=on \
   CGO_ENABLED=0 \
-  GOOS=linux \
-  GOARCH=amd64
+  GOOS=linux
 
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
## Description

Removes `GOARCH` to ensure the Go toolchain does not cross compile, ensures the Go toolchain compiles for the local platform. When running on amd64 this results in an amd64 build, and on armv8 this results in an armv8 build.

<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.

If your changes includes important functionality or bug fixes, please add an entry in the CHANGELOG.md file in the `# Unreleased` section. Or open a follow-up PR to update the CHANGELOG.md with a note on your changes.
-->

## Testing plan

I can reproduce building the amd64 version of `tfci` on an arm machine:

```
> uname -a
Darwin giannigambetti-QWX723M2KW 23.5.0 Darwin Kernel Version 23.5.0: Wed May  1 20:12:58 PDT 2024; root:xnu-10063.121.3~5/RELEASE_ARM64_T6000 arm64
> docker buildx build .
> docker create <image-id>
> docker cp <container-id>:/usr/local/bin/tfci .
> file tfci
```

Before removing `GOARCH`: `tfci: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=DffVugsDq3wO1Mk_H00e/2vP_KXpCh8-ymBb5vwvs/AH6cx2NYXgnKG7YZLVF4/TtOShnVZAi2meWCOGZcy, stripped`

After removing `GOARCH`: `tfci: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=lZfNLtPF7Dt3jyk0LxMK/keckEcuSbZzjWM5rWg1m/QLrnwdBJq6tOcsI2FTeN/LcxFlMZY3Bzu5KgVuGzh, stripped`

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

Fixes #112.