### PR TITLE
[first-time] Check for existing runs when a workspace is locked

### DIFF
--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -137,7 +137,7 @@ func (service *runService) CreateRun(ctx context.Context, options CreateRunOptio
 		return nil, err
 	}
 
-	if w.Locked && !options.PlanOnly {
+	if w.Locked && !options.PlanOnly && !w.CurrentRun {
 		return nil, errors.New("run has been specified as non-speculative and the workspace is currently locked")
 	}
 

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -137,7 +137,7 @@ func (service *runService) CreateRun(ctx context.Context, options CreateRunOptio
 		return nil, err
 	}
 
-	if w.Locked && !options.PlanOnly && !w.CurrentRun {
+	if w.Locked && !options.PlanOnly && w.CurrentRun != nil {
 		return nil, errors.New("run has been specified as non-speculative and the workspace is currently locked")
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.

If your changes includes important functionality or bug fixes, please add an entry in the CHANGELOG.md file in the `# Unreleased` section. Or open a follow-up PR to update the CHANGELOG.md with a note on your changes.
-->

## Description

As multiple integrations attempt to trigger runs on a workspace, it can happen that one integration triggers a run on a workspace while it is locked and applying an existing run.

In the current logic, when a new run is attempted as the workspace has an existing run, it fails out with an error stating that the workspace is locked.

In desired behavior, if a workspace is locked due to an existing/pending run, it should queue the the run.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->
1. Initiate a run on a workspace
2. Trigger a new run while the workspace is planning or applying
3. If the newly triggered run triggers instead of errors, consider success

## External links

Fixes #121 
<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
