### PR TITLE
🐛 Add "post_plan_completed" to the desired states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # UNRELEASED
 
+## Notes
+* Fix issue with `run create` command not handling post-plan status by @sam-mosleh [#137](https://github.com/hashicorp/tfc-workflows-tooling/pull/137)
+
 # v1.3.1
 
 ## Notes

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -510,6 +510,7 @@ func getDesiredRunStatus(run *tfe.Run, policyChecksEnabled bool, costEstimateEna
 		tfe.RunPolicySoftFailed,
 		tfe.RunPlannedAndFinished,
 		tfe.RunApplied,
+		tfe.RunPostPlanCompleted,
 	}
 
 	if run.SavePlan {


### PR DESCRIPTION
## Description

Fixes #136 

## Testing plan

simply execute `tfci run create` in a workspace that already has a post-plan job.