### PR TITLE
Add refresh option

### DIFF
--- a/.github/actions/test-create-run/action.yml
+++ b/.github/actions/test-create-run/action.yml
@@ -40,6 +40,10 @@ inputs:
     required: false
     description: "Specifies whether to create a saved plan. Saved-plan runs perform their plan and checks immediately, but won't lock the workspace and become its current run until they are confirmed for apply."
     default: "false"
+  refresh:
+    required: false
+    description: "When this value is false, skip checking for external changes to remote objects while creating the plan. This can potentially make planning faster, but at the expense of possibly planning against a stale record of the remote system state."
+    default: "true"
 
 outputs:
   status:
@@ -82,3 +86,4 @@ runs:
   - -message=${{ inputs.message }}
   - -plan-only=${{ inputs.plan_only }}
   - -save-plan=${{ inputs.save_plan }}
+  - -refresh=${{ inputs.refresh }}

--- a/internal/cloud/run.go
+++ b/internal/cloud/run.go
@@ -59,6 +59,7 @@ type CreateRunOptions struct {
 	Message                string
 	PlanOnly               bool
 	IsDestroy              bool
+	Refresh                bool
 	SavePlan               bool
 	RunVariables           []*tfe.RunVariable
 	TargetAddrs            []string
@@ -160,6 +161,7 @@ func (service *runService) CreateRun(ctx context.Context, options CreateRunOptio
 	createOpts.Message = &options.Message
 	createOpts.PlanOnly = tfe.Bool(options.PlanOnly)
 	createOpts.IsDestroy = tfe.Bool(options.IsDestroy)
+	createOpts.Refresh = tfe.Bool(options.Refresh)
 	createOpts.SavePlan = tfe.Bool(options.SavePlan)
 	createOpts.Variables = options.RunVariables
 	createOpts.TargetAddrs = options.TargetAddrs

--- a/internal/cloud/run_test.go
+++ b/internal/cloud/run_test.go
@@ -44,6 +44,7 @@ func testGenerateServiceMocks(t *testing.T, ctrl *gomock.Controller, tc createRu
 		Workspace:            tc.tfeWorkspace,
 		PlanOnly:             tfe.Bool(tc.tfeRun.PlanOnly),
 		IsDestroy:            tfe.Bool(tc.tfeRun.IsDestroy),
+		Refresh:              tfe.Bool(tc.tfeRun.Refresh),
 		SavePlan:             tfe.Bool(tc.tfeRun.SavePlan),
 		Message:              tfe.String(""),
 		Variables:            []*tfe.RunVariable{},
@@ -166,6 +167,33 @@ func TestRunService_CreateRun(t *testing.T) {
 				PolicyChecks: []*tfe.PolicyCheck{
 					{ID: "pol-****"},
 				},
+			},
+			statusChanges: []tfe.RunStatus{
+				tfe.RunPlanning,
+				tfe.RunPlanned,
+				tfe.RunCostEstimated,
+			},
+			finalStatus: tfe.RunPolicyChecked,
+		},
+		{
+			name:          "no-refresh-run",
+			orgName:       "test",
+			workspaceName: "my-workspace",
+			ctx:           context.Background(),
+			tfeWorkspace:  &tfe.Workspace{ID: "ws-***"},
+			tfeConfigVersion: &tfe.ConfigurationVersion{
+				ID:     "cv-***",
+				Status: tfe.ConfigurationUploaded,
+			},
+			tfeRun: &tfe.Run{
+				ID: "run-***",
+				CostEstimate: &tfe.CostEstimate{
+					ID: "cost-******",
+				},
+				PolicyChecks: []*tfe.PolicyCheck{
+					{ID: "pol-****"},
+				},
+				Refresh: false,
 			},
 			statusChanges: []tfe.RunStatus{
 				tfe.RunPlanning,

--- a/internal/command/run_create.go
+++ b/internal/command/run_create.go
@@ -23,6 +23,7 @@ type CreateRunCommand struct {
 
 	PlanOnly  bool
 	IsDestroy bool
+	Refresh   bool
 	SavePlan  bool
 }
 
@@ -55,6 +56,7 @@ func (c *CreateRunCommand) flags() *flag.FlagSet {
 	f.BoolVar(&c.PlanOnly, "plan-only", false, "Specifies if this is a HCP Terraform speculative, plan-only run that cannot be applied.")
 	f.BoolVar(&c.IsDestroy, "is-destroy", false, "Specifies that the plan is a destroy plan. When true, the plan destroys all provisioned resources.")
 	f.BoolVar(&c.SavePlan, "save-plan", false, "Specifies whether to create a saved plan. Saved-plan runs perform their plan and checks immediately, but won't lock the workspace and become its current run until they are confirmed for apply.")
+	f.BoolVar(&c.Refresh, "refresh", true, "When this value is false, skip checking for external changes to remote objects while creating the plan. This can potentially make planning faster, but at the expense of possibly planning against a stale record of the remote system state.")
 	f.Var((*flagStringSlice)(&c.TargetAddrs), "target", "Limit the planning operation to only the given module, resource, or resource instance and all of its dependencies. You can use this option multiple times to include more than one object. This is for exceptional use only. e.g. -target=aws_s3_bucket.foo")
 	return f
 }
@@ -78,6 +80,7 @@ func (c *CreateRunCommand) Run(args []string) int {
 		Message:                c.Message,
 		PlanOnly:               c.PlanOnly,
 		IsDestroy:              c.IsDestroy,
+		Refresh:                c.Refresh,
 		SavePlan:               c.SavePlan,
 		RunVariables:           runVars,
 		TargetAddrs:            c.TargetAddrs,
@@ -182,6 +185,7 @@ Options:
 
 	-plan-only              Specifies if this is a HCP Terraform speculative, plan-only run that cannot be applied.
 
+	-refresh=false          Skip checking for external changes to remote objects while creating the plan. This can potentially make planning faster, but at the expense of possibly planning against a stale record of the remote system state.
 	-save-plan              Specifies whether to create a saved plan. Saved-plan runs perform their plan and checks immediately, but won't lock the workspace and become its current run until they are confirmed for apply.
 	-is-destroy				Specifies whether to create a destroy run.
 	-target					Focuses Terraform's attention on only a subset of resources and their dependencies. This option accepts multiple instances by providing additional target option flags.


### PR DESCRIPTION
## Description
Include the option to set `refresh` in order to skip checking for external changes to remote objects while creating the plan (same behaviour as executing terraform cli with `-refresh=value`.

This PR fixes #151 issue.

## Testing plan
Included a test to include `-refresh=false` in the run creation.

## External links
- [Blog entry for terraform cli](https://www.hashicorp.com/en/blog/new-terraform-planning-options-refresh-false-refresh-only-replace)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run) : included data.attributes.refresh` parameter.
