### PR TITLE
chore: prepare v1.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # UNRELEASED
 
+# v1.3.4
+
+## Enhancements
+* Adds support for `-refresh` option to the `run create` command by @mpucholblasco [#154](https://github.com/hashicorp/tfc-workflows-tooling/pull/154)
+
 # v1.3.3
 * Bumps tfci go version to `v1.23` by @mjyocca [#141](https://github.com/hashicorp/tfc-workflows-tooling/pull/141)
 * Go Dependency cleanup (`tidy`) by @mjyocca [#143](https://github.com/hashicorp/tfc-workflows-tooling/pull/143)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-tooling! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.

If your changes includes important functionality or bug fixes, please add an entry in the CHANGELOG.md file in the `# Unreleased` section. Or open a follow-up PR to update the CHANGELOG.md with a note on your changes.
-->

## Description

Prepares v1.3.4 release with included enhancement to allow `run create` command to utilize the new `-refresh=false` option.

## External links
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#create-a-run)
- [Related PR](https://github.com/hashicorp/tfc-workflows-tooling/pull/154)
